### PR TITLE
Change 'ez' to 'simple' to align with repo name

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -23,7 +23,7 @@ The resulting binary will be in the generated `build/` dir
 $ make build
 
 $ ls build/
-ez-ec2
+simple-ec2
 ```
 
 ## Test

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,14 +19,14 @@ COPY . .
 RUN make build
 # In case the target is build for testing:
 # $ docker build  --target=builder -t test .
-CMD ["/aws-simple-ec2-cli/build/ez-ec2"]
+CMD ["/aws-simple-ec2-cli/build/simple-ec2"]
 
 # Copy the binary into a thin image
 FROM amazonlinux:2 as amazonlinux
 FROM scratch
 WORKDIR /
-COPY --from=builder /aws-simple-ec2-cli/build/ez-ec2 .
+COPY --from=builder /aws-simple-ec2-cli/build/simple-ec2 .
 COPY --from=amazonlinux /etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/
 COPY THIRD_PARTY_LICENSES .
 USER 1000
-ENTRYPOINT ["/ez-ec2"]
+ENTRYPOINT ["/simple-ec2"]

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 MAKEFILE_PATH = $(dir $(realpath -s $(firstword $(MAKEFILE_LIST))))
-PROJECT_IMPORT_DIR = ez-ec2
+PROJECT_IMPORT_DIR = simple-ec2
 BUILD_DIR_PATH = ${MAKEFILE_PATH}/build
-CLI_BINARY_NAME = ez-ec2
+CLI_BINARY_NAME = simple-ec2
 VERSION ?= $(shell git describe --tags --always --dirty)
-BIN ?= ez-ec2
+BIN ?= simple-ec2
 REPO_FULL_NAME ?= awslabs/aws-simple-ec2-cli
 GOOS ?= $(uname | tr '[:upper:]' '[:lower:]')
 GOARCH ?= amd64
@@ -14,9 +14,9 @@ LATEST_RELEASE_TAG=$(shell git tag | tail -1)
 PREVIOUS_RELEASE_TAG=$(shell git tag | tail -2 | head -1)
 
 # The main CloudFormation template for creating a new stack during launch
-EZEC2_CLOUDFORMATION_TEMPLATE_FILE=${MAKEFILE_PATH}/cloudformation_template.json
-EZEC2_CLOUDFORMATION_TEMPLATE_ENCODED=$(shell cat ${EZEC2_CLOUDFORMATION_TEMPLATE_FILE} | base64 | tr -d \\n)
-EZEC2_CLOUDFORMATION_TEMPLATE_VAR=${PROJECT_IMPORT_DIR}/pkg/cfn.Ezec2CloudformationTemplateEncoded
+SIMPLE_EC2_CLOUDFORMATION_TEMPLATE_FILE=${MAKEFILE_PATH}/cloudformation_template.json
+SIMPLE_EC2_CLOUDFORMATION_TEMPLATE_ENCODED=$(shell cat ${SIMPLE_EC2_CLOUDFORMATION_TEMPLATE_FILE} | base64 | tr -d \\n)
+SIMPLE_EC2_CLOUDFORMATION_TEMPLATE_VAR=${PROJECT_IMPORT_DIR}/pkg/cfn.SimpleEc2CloudformationTemplateEncoded
 
 # The CloudFormation template for e2e cfn test
 E2E_CFN_TEST_CLOUDFORMATION_TEMPLATE_FILE=${MAKEFILE_PATH}/test/e2e/e2e-cfn-test/cloudformation_template.json
@@ -33,12 +33,12 @@ E2E_EC2HELPER_TEST_CLOUDFORMATION_TEMPLATE_FILE=${MAKEFILE_PATH}/test/e2e/e2e-ec
 E2E_EC2HELPER_TEST_CLOUDFORMATION_TEMPLATE_ENCODED=$(shell cat ${E2E_EC2HELPER_TEST_CLOUDFORMATION_TEMPLATE_FILE} | base64 | tr -d \\n)
 E2E_EC2HELPER_TEST_CLOUDFORMATION_TEMPLATE_VAR=${PROJECT_IMPORT_DIR}/pkg/cfn.E2eEc2helperTestCloudformationTemplateEncoded
 
-EMBED_TEMPLATE_FLAG=-ldflags '-X "${EZEC2_CLOUDFORMATION_TEMPLATE_VAR}=${EZEC2_CLOUDFORMATION_TEMPLATE_ENCODED}"\
+EMBED_TEMPLATE_FLAG=-ldflags '-X "${SIMPLE_EC2_CLOUDFORMATION_TEMPLATE_VAR}=${SIMPLE_EC2_CLOUDFORMATION_TEMPLATE_ENCODED}"\
  -X "${E2E_CFN_TEST_CLOUDFORMATION_TEMPLATE_VAR}=${E2E_CFN_TEST_CLOUDFORMATION_TEMPLATE_ENCODED}"\
  -X "${E2E_CONNECT_TEST_CLOUDFORMATION_TEMPLATE_VAR}=${E2E_CONNECT_TEST_CLOUDFORMATION_TEMPLATE_ENCODED}"\
  -X "${E2E_EC2HELPER_TEST_CLOUDFORMATION_TEMPLATE_VAR}=${E2E_EC2HELPER_TEST_CLOUDFORMATION_TEMPLATE_ENCODED}"'
 
-E2E_TEST_PACKAGES=ez-ec2/test/e2e/...
+E2E_TEST_PACKAGES=simple-ec2/test/e2e/...
 
 GO_TEST=go test ${EMBED_TEMPLATE_FLAG} -bench=. ${MAKEFILE_PATH}
 DELETE_STACK=aws cloudformation delete-stack --stack-name 
@@ -64,20 +64,20 @@ unit-test:
 
 e2e-test:
 	${GO_TEST}/test/e2e/... -v
-	${DELETE_STACK}ez-ec2-e2e-cfn-test
-	${DELETE_STACK}ez-ec2-e2e-connect-test
-	${DELETE_STACK}ez-ec2-e2e-ec2helper-test
+	${DELETE_STACK}simple-ec2-e2e-cfn-test
+	${DELETE_STACK}simple-ec2-e2e-connect-test
+	${DELETE_STACK}simple-ec2-e2e-ec2helper-test
 
 e2e-cfn-test:
 	${GO_TEST}/test/e2e/e2e-cfn-test/... -v
-	${DELETE_STACK}ez-ec2-e2e-cfn-test
+	${DELETE_STACK}simple-ec2-e2e-cfn-test
 
 e2e-connect-test:
 	${GO_TEST}/test/e2e/e2e-connect-test/... -v
-	${DELETE_STACK}ez-ec2-e2e-connect-test
+	${DELETE_STACK}simple-ec2-e2e-connect-test
 
 e2e-ec2helper-test:
 	${GO_TEST}/test/e2e/e2e-ec2helper-test/... -v
-	${DELETE_STACK}ez-ec2-e2e-ec2helper-test
+	${DELETE_STACK}simple-ec2-e2e-ec2helper-test
 
 test: unit-test e2e-test

--- a/Makefile
+++ b/Makefile
@@ -81,3 +81,6 @@ e2e-ec2helper-test:
 	${DELETE_STACK}simple-ec2-e2e-ec2helper-test
 
 test: unit-test e2e-test
+
+fmt:
+	goimports -w ./ && gofmt -s -w ./

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ In order to launch a new EC2 instance, customers need to specify a lot of option
 1. Install AWS Simple EC2 CLI
 
 ```
-go install ez-ec2
+go install simple-ec2
 ```
 
 2. Install sshpass (1.06+)
@@ -64,12 +64,12 @@ export AWS_SECRET_ACCESS_KEY="..."
 **All CLI Options**
 
 ```
-$ ez-ec2 launch -h
+$ simple-ec2 launch -h
 Launch an Amazon EC2 instance with the default configurations. 
 	All configurations can be overridden by configurations provided by configuration files or user input
 
 Usage:
-  ez-ec2 launch [flags]
+  simple-ec2 launch [flags]
 
 Flags:
   -a, --auto-termination-timer int       The auto-termination timer for the instance in minutes
@@ -89,7 +89,7 @@ Flags:
 **Single Command Launch**
 
 ```
-$ ez-ec2 launch
+$ simple-ec2 launch
 
 Please confirm if you would like to launch instance with following options: 
 +----------------+-------------------------------------------------+
@@ -99,7 +99,7 @@ Please confirm if you would like to launch instance with following options:
 | Instance Type  | t2.micro                                        |
 | Image          | ami-123example                                  |
 | Security Group | Default SG(sg-123example)                       |
-|                | ez-ec2 SSH Security Group(sg-123example)        |
+|                | simple-ec2 SSH Security Group(sg-123example)    |
 | EBS Volumes    | /dev/xvda(gp2): 8 GiB                           |
 +----------------+-------------------------------------------------+
 [ yes / no ]
@@ -112,7 +112,7 @@ Instance ID: i-123example
 **Single Command Launch With Flags**
 
 ```
-$ ez-ec2 launch -r us-east-2 -m ami-123example -t t2.micro -s subnet-123example -g sg-123example
+$ simple-ec2 launch -r us-east-2 -m ami-123example -t t2.micro -s subnet-123example -g sg-123example
 
 Please confirm if you would like to launch instance with following options: 
 +----------------+-------------------------------------------------+
@@ -121,7 +121,7 @@ Please confirm if you would like to launch instance with following options:
 | Subnet         | subnet-123example                               |
 | Instance Type  | t2.micro                                        |
 | Image          | ami-123example                                  |
-| Security Group | ez-ec2 SSH Security(sg-123example)              |
+| Security Group | simple-ec2 SSH Security(sg-123example)          |
 | EBS Volumes    | /dev/xvda(gp2): 8 GiB                           |
 +----------------+-------------------------------------------------+
 [ yes / no ]
@@ -134,7 +134,7 @@ Instance ID: i-123example
 **Interactive Mode Launch**
 
 ```
-$ ez-ec2 launch -i
+$ simple-ec2 launch -i
 
 Select the region you wish to launch the instance: [default: us-east-2]
 +------------------+---------------------------+------------------+-------------------------+
@@ -211,7 +211,7 @@ What security group would you like to use?
 | OPTION |                 SECURITY GROUP                  |                      DESCRIPTION                      |
 +--------+-------------------------------------------------+-------------------------------------------------------+
 | 1.     | Default SSH SG(sg-123example)                   | launch-wizard-1 created 2020-06-07T19:45:39.448-04:00 |
-| 2.     | ez-ec2 SSH Security Group(sg-123example)        | Created by ez-ec2 for SSH connection to instances     |
+| 2.     | simple-ec2 SSH Security Group(sg-123example)    | Created by simple-ec2 for SSH connection to instances |
 | 3.     | Default SG(sg-123example)                       | default VPC security group                            |
 | 4.     | Add all available security groups               |
 | 5.     | Create a new security group that enables SSH    |
@@ -237,7 +237,7 @@ Please confirm if you would like to launch instance with following options:
 | 2.Subnet         | My Default Subnet(subnet-123example)            |
 | 3.Instance Type  | t2.nano                                         |
 | 4.Image          | ami-123example                                  |
-| 5.Security Group | ez-ec2 SSH Security Group(sg-123example)        |
+| 5.Security Group | simple-ec2 SSH Security Group(sg-123example)    |
 | EBS Volumes      | /dev/xvda(gp2): 8 GiB                           |
 +------------------+-------------------------------------------------+
 [ yes / no ]
@@ -250,7 +250,7 @@ Do you want to save the configuration above as a JSON file that can be used in n
 [ yes / no ]
 yes
 Saving config...
-Config successfully saved: /Users/$USER/.ez-ec2/ez-ec2.json
+Config successfully saved: /Users/$USER/.simple-ec2/simple-ec2.json
 ```
 
 ### Connect
@@ -258,11 +258,11 @@ Config successfully saved: /Users/$USER/.ez-ec2/ez-ec2.json
 **All CLI Options**
 
 ```
-$ ez-ec2 connect -h
+$ simple-ec2 connect -h
 Connect to an Amazon EC2 Instance, given the region and instance id
 
 Usage:
-  ez-ec2 connect [flags]
+  simple-ec2 connect [flags]
 
 Flags:
   -h, --help                 help for connect
@@ -275,7 +275,7 @@ Flags:
 **Single Command Connect**
 
 ```
-$ ez-ec2 connect -r us-east-2 -n i-123example
+$ simple-ec2 connect -r us-east-2 -n i-123example
 Last login: Wed Jul 29 21:01:45 2020 from 52.95.4.1
 
        __|  __|_  )
@@ -293,7 +293,7 @@ logout
 **Interactive Mode Connect**
 
 ```
-$ ez-ec2 connect -i
+$ simple-ec2 connect -i
 
 Select the region you wish to launch the instance: [default: us-east-2]
 +------------------+---------------------------+------------------+-------------------------+
@@ -314,9 +314,9 @@ Select the instance you want to connect to:
 +--------+---------------------+-------------+------------------------+
 | OPTION |      INSTANCE       |   TAG-KEY   |       TAG-VALUE        |
 +--------+---------------------+-------------+------------------------+
-| 1.     | i-123example        | CreatedBy   | ez-ec2                 |
+| 1.     | i-123example        | CreatedBy   | simple-ec2             |
 |        |                     | CreatedTime | 2020-7-29 16:38:52 EDT |
-| 2.     | i-123example        | CreatedBy   | ez-ec2                 |
+| 2.     | i-123example        | CreatedBy   | simple-ec2             |
 |        |                     | CreatedTime | 2020-7-29 16:35:48 EDT |
 +--------+---------------------+-------------+------------------------+
 2
@@ -337,11 +337,11 @@ logout
 **All CLI Options**
 
 ```
-$ ez-ec2 terminate -h
+$ simple-ec2 terminate -h
 Terminate Amazon EC2 Instances, given the region and instance ids
 
 Usage:
-  ez-ec2 terminate [flags]
+  simple-ec2 terminate [flags]
 
 Flags:
   -h, --help                   help for terminate
@@ -353,7 +353,7 @@ Flags:
 **One Command Terminate**
 
 ```
-$ ez-ec2 terminate -r us-east-2 -n i-123example
+$ simple-ec2 terminate -r us-east-2 -n i-123example
 Terminating instances
 Instances [i-123example] terminated successfully
 ```
@@ -361,7 +361,7 @@ Instances [i-123example] terminated successfully
 **Interactive Terminate**
 
 ```
-$ ez-ec2 terminate -i
+$ simple-ec2 terminate -i
 
 Select the region you wish to launch the instance: [default: us-east-2]
 +------------------+---------------------------+------------------+-------------------------+
@@ -382,9 +382,9 @@ Select the instance you want to terminate:
 +--------+---------------------+-------------+------------------------+
 | OPTION |      INSTANCE       |   TAG-KEY   |       TAG-VALUE        |
 +--------+---------------------+-------------+------------------------+
-| 1.     | i-123example        | CreatedBy   | ez-ec2                 |
+| 1.     | i-123example        | CreatedBy   | simple-ec2             |
 |        |                     | CreatedTime | 2020-7-29 16:38:52 EDT |
-| 2.     | i-456example        | CreatedBy   | ez-ec2                 |
+| 2.     | i-456example        | CreatedBy   | simple-ec2             |
 |        |                     | CreatedTime | 2020-7-29 16:35:48 EDT |
 +--------+---------------------+-------------+------------------------+
 1
@@ -393,7 +393,7 @@ Select the instance you want to terminate:
 +--------+--------------------------------+-------------+------------------------+
 | OPTION |            INSTANCE            |   TAG-KEY   |       TAG-VALUE        |
 +--------+--------------------------------+-------------+------------------------+
-| 1.     | i-456example                   | CreatedBy   | ez-ec2                 |
+| 1.     | i-456example                   | CreatedBy   | simple-ec2             |
 |        |                                | CreatedTime | 2020-7-29 16:35:48 EDT |
 | 2.     | Don't add any more instance id |
 +--------+--------------------------------+-------------+------------------------+

--- a/cloudformation_template.json
+++ b/cloudformation_template.json
@@ -9,7 +9,7 @@
                 "Tags": [
                     {
                         "Key": "Name",
-                        "Value": "ez-ec2 VPC"
+                        "Value": "simple-ec2 VPC"
                     }
                 ]
             }
@@ -25,7 +25,7 @@
                 "Tags": [
                     {
                         "Key": "Name",
-                        "Value": "ez-ec2 Subnet"
+                        "Value": "simple-ec2 Subnet"
                     }
                 ],
                 "VpcId": {
@@ -44,7 +44,7 @@
                 "Tags": [
                     {
                         "Key": "Name",
-                        "Value": "ez-ec2 Subnet"
+                        "Value": "simple-ec2 Subnet"
                     }
                 ],
                 "VpcId": {
@@ -63,7 +63,7 @@
                 "Tags": [
                     {
                         "Key": "Name",
-                        "Value": "ez-ec2 Subnet"
+                        "Value": "simple-ec2 Subnet"
                     }
                 ],
                 "VpcId": {

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -17,10 +17,10 @@ import (
 	"fmt"
 	"strings"
 
-	"ez-ec2/pkg/cli"
-	"ez-ec2/pkg/ec2helper"
-	ec2ichelper "ez-ec2/pkg/ec2instanceconnecthelper"
-	"ez-ec2/pkg/question"
+	"simple-ec2/pkg/cli"
+	"simple-ec2/pkg/ec2helper"
+	ec2ichelper "simple-ec2/pkg/ec2instanceconnecthelper"
+	"simple-ec2/pkg/question"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/spf13/cobra"

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -14,7 +14,7 @@
 package cmd
 
 import (
-	"ez-ec2/pkg/config"
+	"simple-ec2/pkg/config"
 )
 
 // Used for flags

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -17,10 +17,10 @@ import (
 	"fmt"
 	"strconv"
 
-	"ez-ec2/pkg/cli"
-	"ez-ec2/pkg/config"
-	"ez-ec2/pkg/ec2helper"
-	"ez-ec2/pkg/question"
+	"simple-ec2/pkg/cli"
+	"simple-ec2/pkg/config"
+	"simple-ec2/pkg/ec2helper"
+	"simple-ec2/pkg/question"
 
 	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector"
 	"github.com/aws/aws-sdk-go/aws/session"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,8 +15,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 var rootCmd = &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,12 +20,12 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "ez-ec2",
-	Short: "AWS Simple EC2 CLI (ez-ec2) is a simple tool to launch, connect and terminate Amazon EC2 instances",
-	Long: `AWS Simple EC2 CLI (ez-ec2) is a simple tool to launch, connect and terminate Amazon EC2 instances.
+	Use:   "simple-ec2",
+	Short: "AWS Simple EC2 CLI (simple-ec2) is a simple tool to launch, connect and terminate Amazon EC2 instances",
+	Long: `AWS Simple EC2 CLI (simple-ec2) is a simple tool to launch, connect and terminate Amazon EC2 instances.
 	Users can easily launch an instance with or without custom configurations.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("This command cannot be used alone. Please refer to ez-ec2 --help for available command combinations")
+		fmt.Println("This command cannot be used alone. Please refer to simple-ec2 --help for available command combinations")
 	},
 }
 

--- a/cmd/terminate.go
+++ b/cmd/terminate.go
@@ -17,9 +17,9 @@ import (
 	"fmt"
 	"strings"
 
-	"ez-ec2/pkg/cli"
-	"ez-ec2/pkg/ec2helper"
-	"ez-ec2/pkg/question"
+	"simple-ec2/pkg/cli"
+	"simple-ec2/pkg/ec2helper"
+	"simple-ec2/pkg/question"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/spf13/cobra"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module ez-ec2
+module simple-ec2
 
 go 1.15
 

--- a/main.go
+++ b/main.go
@@ -17,8 +17,8 @@ import (
 	"fmt"
 	"os"
 
-	"ez-ec2/cmd"
-	"ez-ec2/pkg/cfn"
+	"simple-ec2/cmd"
+	"simple-ec2/pkg/cfn"
 )
 
 func main() {

--- a/pkg/cfn/cfn.go
+++ b/pkg/cfn/cfn.go
@@ -105,15 +105,15 @@ func (c Cfn) CreateStack(stackName, template string, zones []*ec2.AvailabilityZo
 
 	if zones != nil && len(zones) > 0 {
 		input.Parameters = []*cloudformation.Parameter{
-			&cloudformation.Parameter{
+			{
 				ParameterKey:   aws.String("AZ0"),
 				ParameterValue: zones[0].ZoneName,
 			},
-			&cloudformation.Parameter{
+			{
 				ParameterKey:   aws.String("AZ1"),
 				ParameterValue: zones[1].ZoneName,
 			},
-			&cloudformation.Parameter{
+			{
 				ParameterKey:   aws.String("AZ2"),
 				ParameterValue: zones[2].ZoneName,
 			},

--- a/pkg/cfn/cfn.go
+++ b/pkg/cfn/cfn.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"time"
 
-	"ez-ec2/pkg/tag"
+	"simple-ec2/pkg/tag"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -26,7 +26,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
-const DefaultStackName = "ez-ec2"
+const DefaultStackName = "simple-ec2"
 const creationCheckInterval = time.Second
 const RequiredAvailabilityZones = 3
 const PostCreationWait = time.Second * 60
@@ -100,7 +100,7 @@ func (c Cfn) CreateStack(stackName, template string, zones []*ec2.AvailabilityZo
 	input := &cloudformation.CreateStackInput{
 		StackName:    aws.String(stackName),
 		TemplateBody: aws.String(template),
-		Tags:         getEzec2Tags(),
+		Tags:         getSimpleEc2Tags(),
 	}
 
 	if zones != nil && len(zones) > 0 {
@@ -213,17 +213,17 @@ func (c Cfn) DeleteStack(stackName string) error {
 	return nil
 }
 
-// Get the tags for resources created by ez-ec2
-func getEzec2Tags() []*cloudformation.Tag {
-	ezec2Tags := []*cloudformation.Tag{}
+// Get the tags for resources created by simple-ec2
+func getSimpleEc2Tags() []*cloudformation.Tag {
+	simpleEc2Tags := []*cloudformation.Tag{}
 
 	tags := tag.GetTags()
 	for key, value := range *tags {
-		ezec2Tags = append(ezec2Tags, &cloudformation.Tag{
+		simpleEc2Tags = append(simpleEc2Tags, &cloudformation.Tag{
 			Key:   aws.String(key),
 			Value: aws.String(value),
 		})
 	}
 
-	return ezec2Tags
+	return simpleEc2Tags
 }

--- a/pkg/cfn/cfn_test.go
+++ b/pkg/cfn/cfn_test.go
@@ -47,43 +47,43 @@ var testSubnetIds = []string{
 }
 
 var mockedResources = []*cloudformation.StackResource{
-	&cloudformation.StackResource{
+	{
 		ResourceType:       aws.String(cfn.ResourceTypeVpc),
 		PhysicalResourceId: aws.String(testVpcId),
 	},
-	&cloudformation.StackResource{
+	{
 		ResourceType:       aws.String(cfn.ResourceTypeSubnet),
 		PhysicalResourceId: aws.String(testSubnetIds[0]),
 	},
-	&cloudformation.StackResource{
+	{
 		ResourceType:       aws.String(cfn.ResourceTypeSubnet),
 		PhysicalResourceId: aws.String(testSubnetIds[1]),
 	},
-	&cloudformation.StackResource{
+	{
 		ResourceType:       aws.String(cfn.ResourceTypeInstance),
 		PhysicalResourceId: aws.String(testInstanceId),
 	},
 }
 
 var mockedEvents = []*cloudformation.StackEvent{
-	&cloudformation.StackEvent{
+	{
 		LogicalResourceId: aws.String(cfn.DefaultStackName),
 		ResourceStatus:    aws.String(cloudformation.ResourceStatusCreateComplete),
 	},
-	&cloudformation.StackEvent{
+	{
 		LogicalResourceId: aws.String("Test Resource"),
 		ResourceStatus:    aws.String(cloudformation.ResourceStatusCreateComplete),
 	},
 }
 
 var testAzs = []*ec2.AvailabilityZone{
-	&ec2.AvailabilityZone{
+	{
 		ZoneName: aws.String("AZ1"),
 	},
-	&ec2.AvailabilityZone{
+	{
 		ZoneName: aws.String("AZ2"),
 	},
-	&ec2.AvailabilityZone{
+	{
 		ZoneName: aws.String("AZ3"),
 	},
 }
@@ -140,7 +140,7 @@ func TestCreateStackAndGetResources_DescribeStackResourcesError(t *testing.T) {
 func TestCreateStackAndGetResources_NoSubnet(t *testing.T) {
 	testCfn.Svc = &th.MockedCfnSvc{
 		StackResources: []*cloudformation.StackResource{
-			&cloudformation.StackResource{
+			{
 				ResourceType:       aws.String(cfn.ResourceTypeVpc),
 				PhysicalResourceId: aws.String("vpc-12345"),
 			},
@@ -157,11 +157,11 @@ func TestCreateStackAndGetResources_NoSubnet(t *testing.T) {
 func TestCreateStackAndGetResources_NoVpc(t *testing.T) {
 	testCfn.Svc = &th.MockedCfnSvc{
 		StackResources: []*cloudformation.StackResource{
-			&cloudformation.StackResource{
+			{
 				ResourceType:       aws.String(cfn.ResourceTypeSubnet),
 				PhysicalResourceId: aws.String("subnet-12345"),
 			},
-			&cloudformation.StackResource{
+			{
 				ResourceType:       aws.String(cfn.ResourceTypeSubnet),
 				PhysicalResourceId: aws.String("subnet-67890"),
 			},

--- a/pkg/cfn/cfn_test.go
+++ b/pkg/cfn/cfn_test.go
@@ -17,8 +17,8 @@ import (
 	"errors"
 	"testing"
 
-	"ez-ec2/pkg/cfn"
-	th "ez-ec2/test/testhelper"
+	"simple-ec2/pkg/cfn"
+	th "simple-ec2/test/testhelper"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"

--- a/pkg/cfn/template.go
+++ b/pkg/cfn/template.go
@@ -36,10 +36,10 @@ var (
 // Decode all encoded CloudFormation template strings into corresponding variables
 func DecodeTemplateVariables() (err error) {
 	templatePairs := [][]*string{
-		[]*string{&SimpleEc2CloudformationTemplateEncoded, &SimpleEc2CloudformationTemplate},
-		[]*string{&E2eCfnTestCloudformationTemplateEncoded, &E2eCfnTestCloudformationTemplate},
-		[]*string{&E2eConnectTestCloudformationTemplateEncoded, &E2eConnectTestCloudformationTemplate},
-		[]*string{&E2eEc2helperTestCloudformationTemplateEncoded, &E2eEc2helperTestCloudformationTemplate},
+		{&SimpleEc2CloudformationTemplateEncoded, &SimpleEc2CloudformationTemplate},
+		{&E2eCfnTestCloudformationTemplateEncoded, &E2eCfnTestCloudformationTemplate},
+		{&E2eConnectTestCloudformationTemplateEncoded, &E2eConnectTestCloudformationTemplate},
+		{&E2eEc2helperTestCloudformationTemplateEncoded, &E2eEc2helperTestCloudformationTemplate},
 	}
 
 	for _, pair := range templatePairs {

--- a/pkg/cfn/template.go
+++ b/pkg/cfn/template.go
@@ -19,7 +19,7 @@ import (
 
 // Encoded CloudFormation template strings populated by Makefile
 var (
-	Ezec2CloudformationTemplateEncoded            = "{}"
+	SimpleEc2CloudformationTemplateEncoded        = "{}"
 	E2eCfnTestCloudformationTemplateEncoded       = "{}"
 	E2eConnectTestCloudformationTemplateEncoded   = "{}"
 	E2eEc2helperTestCloudformationTemplateEncoded = "{}"
@@ -27,7 +27,7 @@ var (
 
 // Decoded CloudFormation template strings
 var (
-	Ezec2CloudformationTemplate            string
+	SimpleEc2CloudformationTemplate        string
 	E2eCfnTestCloudformationTemplate       string
 	E2eConnectTestCloudformationTemplate   string
 	E2eEc2helperTestCloudformationTemplate string
@@ -36,7 +36,7 @@ var (
 // Decode all encoded CloudFormation template strings into corresponding variables
 func DecodeTemplateVariables() (err error) {
 	templatePairs := [][]*string{
-		[]*string{&Ezec2CloudformationTemplateEncoded, &Ezec2CloudformationTemplate},
+		[]*string{&SimpleEc2CloudformationTemplateEncoded, &SimpleEc2CloudformationTemplate},
 		[]*string{&E2eCfnTestCloudformationTemplateEncoded, &E2eCfnTestCloudformationTemplate},
 		[]*string{&E2eConnectTestCloudformationTemplateEncoded, &E2eConnectTestCloudformationTemplate},
 		[]*string{&E2eEc2helperTestCloudformationTemplateEncoded, &E2eEc2helperTestCloudformationTemplate},

--- a/pkg/cfn/template_test.go
+++ b/pkg/cfn/template_test.go
@@ -16,12 +16,12 @@ package cfn_test
 import (
 	"testing"
 
-	"ez-ec2/pkg/cfn"
-	th "ez-ec2/test/testhelper"
+	"simple-ec2/pkg/cfn"
+	th "simple-ec2/test/testhelper"
 )
 
 // Backup encoded strings
-var backupEzec2String = cfn.Ezec2CloudformationTemplateEncoded
+var backupSimpleEc2String = cfn.SimpleEc2CloudformationTemplateEncoded
 
 func TestDecodeTemplateVariables_Success(t *testing.T) {
 	err := cfn.DecodeTemplateVariables()
@@ -39,5 +39,5 @@ func TestDecodeTemplateVariables_Error(t *testing.T) {
 	}
 
 	// Restore encoded strings
-	cfn.Ezec2CloudformationTemplateEncoded = backupEzec2String
+	cfn.SimpleEc2CloudformationTemplateEncoded = backupSimpleEc2String
 }

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -18,8 +18,8 @@ import (
 	"fmt"
 	"testing"
 
-	"ez-ec2/pkg/cli"
-	th "ez-ec2/test/testhelper"
+	"simple-ec2/pkg/cli"
+	th "simple-ec2/test/testhelper"
 )
 
 func TestShowError_NoError(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,9 +25,9 @@ import (
 	homedir "github.com/mitchellh/go-homedir"
 )
 
-const defaultConfigFileName = "ez-ec2.json"
+const defaultConfigFileName = "simple-ec2.json"
 
-var ezec2Dir = getHomeDir() + "/.ez-ec2"
+var simpleEc2Dir = getHomeDir() + "/.simple-ec2"
 
 /*
 A simple config for reading config files or flags into primitive type information.
@@ -74,7 +74,7 @@ func ReadConfig(simpleConfig *SimpleInfo, configFileName *string) error {
 		configFileName = aws.String(defaultConfigFileName)
 	}
 
-	path := ezec2Dir + "/" + *configFileName
+	path := simpleEc2Dir + "/" + *configFileName
 
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
@@ -149,15 +149,15 @@ func SaveConfig(simpleConfig *SimpleInfo, configFileName *string) error {
 // Save a file in the config folder
 func SaveInConfigFolder(fileName string, data []byte, perm os.FileMode) (*string, error) {
 	// Create the folder if it doesn't exist
-	if _, err := os.Stat(ezec2Dir); os.IsNotExist(err) {
-		err = os.MkdirAll(ezec2Dir, os.ModePerm)
+	if _, err := os.Stat(simpleEc2Dir); os.IsNotExist(err) {
+		err = os.MkdirAll(simpleEc2Dir, os.ModePerm)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	// Save the file
-	path := ezec2Dir + "/" + fileName
+	path := simpleEc2Dir + "/" + fileName
 	err := ioutil.WriteFile(path, data, perm)
 	if err != nil {
 		return nil, err

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -20,15 +20,15 @@ import (
 	"strconv"
 	"testing"
 
-	"ez-ec2/pkg/config"
-	th "ez-ec2/test/testhelper"
+	"simple-ec2/pkg/config"
+	th "simple-ec2/test/testhelper"
 
 	"github.com/aws/aws-sdk-go/aws"
 )
 
 const testConfigFileName = "unit_test_config_temp.json"
 
-var testConfigFilePath = os.Getenv("HOME") + "/.ez-ec2/" + testConfigFileName
+var testConfigFilePath = os.Getenv("HOME") + "/.simple-ec2/" + testConfigFileName
 
 func TestSaveInConfigFolder(t *testing.T) {
 	testString := "unit test config"

--- a/pkg/ec2helper/ec2helper.go
+++ b/pkg/ec2helper/ec2helper.go
@@ -20,10 +20,10 @@ import (
 	"os"
 	"sort"
 
-	"ez-ec2/pkg/cfn"
-	"ez-ec2/pkg/cli"
-	"ez-ec2/pkg/config"
-	"ez-ec2/pkg/tag"
+	"simple-ec2/pkg/cfn"
+	"simple-ec2/pkg/cli"
+	"simple-ec2/pkg/config"
+	"simple-ec2/pkg/tag"
 
 	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/bytequantity"
 	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector"
@@ -718,8 +718,8 @@ func (h *EC2Helper) CreateSecurityGroupForSsh(vpcId string) (*string, error) {
 
 	// Create a new security group
 	creationInput := &ec2.CreateSecurityGroupInput{
-		Description: aws.String("Created by ez-ec2 for SSH connection to instances"),
-		GroupName:   aws.String("ez-ec2 SSH"),
+		Description: aws.String("Created by simple-ec2 for SSH connection to instances"),
+		GroupName:   aws.String("simple-ec2 SSH"),
 		VpcId:       aws.String(vpcId),
 	}
 
@@ -757,9 +757,9 @@ func (h *EC2Helper) CreateSecurityGroupForSsh(vpcId string) (*string, error) {
 	}
 
 	// Create tags
-	tags := append(getEzec2Tags(), &ec2.Tag{
+	tags := append(getSimpleEc2Tags(), &ec2.Tag{
 		Key:   aws.String("Name"),
-		Value: aws.String("ez-ec2 SSH Security Group"),
+		Value: aws.String("simple-ec2 SSH Security Group"),
 	})
 	err = h.createTags([]string{groupId}, tags)
 	if err != nil {
@@ -819,7 +819,7 @@ Empty result is allowed.
 func (h *EC2Helper) GetInstancesByState(states []string) ([]*ec2.Instance, error) {
 	input := &ec2.DescribeInstancesInput{
 		Filters: []*ec2.Filter{
-			&ec2.Filter{
+			{
 				Name:   aws.String("instance-state-name"),
 				Values: aws.StringSlice(states),
 			},
@@ -1037,11 +1037,11 @@ func (h *EC2Helper) LaunchInstance(simpleConfig *config.SimpleInfo, detailedConf
 			}
 		}
 
-		// Add ez-ec2 tags to created resources
+		// Add simple-ec2 tags to created resources
 		input.TagSpecifications = []*ec2.TagSpecification{
 			&ec2.TagSpecification{
 				ResourceType: aws.String("instance"),
-				Tags:         getEzec2Tags(),
+				Tags:         getSimpleEc2Tags(),
 			},
 		}
 		image, err := h.GetImageById(simpleConfig.ImageId)
@@ -1052,7 +1052,7 @@ func (h *EC2Helper) LaunchInstance(simpleConfig *config.SimpleInfo, detailedConf
 				input.TagSpecifications = append(input.TagSpecifications,
 					&ec2.TagSpecification{
 						ResourceType: aws.String("volume"),
-						Tags:         getEzec2Tags(),
+						Tags:         getSimpleEc2Tags(),
 					})
 			}
 		}
@@ -1086,7 +1086,7 @@ func (h *EC2Helper) createNetworkConfiguration(simpleConfig *config.SimpleInfo,
 	// Retrieve resources from the stack
 	c := cfn.New(h.Sess)
 	vpcId, subnetIds, _, _, err := c.CreateStackAndGetResources(availabilityZones, nil,
-		cfn.Ezec2CloudformationTemplate)
+		cfn.SimpleEc2CloudformationTemplate)
 	if err != nil {
 		return err
 	}
@@ -1185,19 +1185,19 @@ func GetTagName(tags []*ec2.Tag) *string {
 	return nil
 }
 
-// Get the tags for resources created by ez-ec2
-func getEzec2Tags() []*ec2.Tag {
-	ezec2Tags := []*ec2.Tag{}
+// Get the tags for resources created by simple-ec2
+func getSimpleEc2Tags() []*ec2.Tag {
+	simpleEc2Tags := []*ec2.Tag{}
 
 	tags := tag.GetTags()
 	for key, value := range *tags {
-		ezec2Tags = append(ezec2Tags, &ec2.Tag{
+		simpleEc2Tags = append(simpleEc2Tags, &ec2.Tag{
 			Key:   aws.String(key),
 			Value: aws.String(value),
 		})
 	}
 
-	return ezec2Tags
+	return simpleEc2Tags
 }
 
 // Validate an image id. Used as a function interface to validate question input

--- a/pkg/ec2helper/ec2helper.go
+++ b/pkg/ec2helper/ec2helper.go
@@ -108,7 +108,7 @@ Empty result is not allowed.
 func (h *EC2Helper) GetAvailableAvailabilityZones() ([]*ec2.AvailabilityZone, error) {
 	input := &ec2.DescribeAvailabilityZonesInput{
 		Filters: []*ec2.Filter{
-			&ec2.Filter{
+			{
 				Name:   aws.String("state"),
 				Values: aws.StringSlice([]string{ec2.AvailabilityZoneStateAvailable}),
 			},
@@ -225,7 +225,7 @@ Empty result is allowed.
 func (h *EC2Helper) GetDefaultFreeTierInstanceType() (*ec2.InstanceTypeInfo, error) {
 	input := &ec2.DescribeInstanceTypesInput{
 		Filters: []*ec2.Filter{
-			&ec2.Filter{
+			{
 				Name: aws.String("free-tier-eligible"),
 				Values: []*string{
 					aws.String("true"),
@@ -345,26 +345,26 @@ func (h *EC2Helper) getInstanceTypes(input *ec2.DescribeInstanceTypesInput) ([]*
 
 // Define all OS and corresponding AMI name formats
 var osDescs = map[string]map[string]string{
-	"Amazon Linux": map[string]string{
+	"Amazon Linux": {
 		"ebs":            "amzn-ami-hvm-????.??.?.????????.?-x86_64-gp2",
 		"instance-store": "amzn-ami-hvm-????.??.?.????????.?-x86_64-s3",
 	},
-	"Amazon Linux 2": map[string]string{
+	"Amazon Linux 2": {
 		"ebs": "amzn2-ami-hvm-2.?.????????.?-x86_64-gp2",
 	},
-	"Red Hat": map[string]string{
+	"Red Hat": {
 		"ebs": "RHEL-?.?.?_HVM-????????-x86_64-?-Hourly2-GP2",
 	},
-	"SUSE Linux": map[string]string{
+	"SUSE Linux": {
 		"ebs": "suse-sles-??-sp?-v????????-hvm-ssd-x86_64",
 	},
 	// Ubuntu 18.04 LTS
-	"Ubuntu": map[string]string{
+	"Ubuntu": {
 		"ebs":            "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-????????",
 		"instance-store": "ubuntu/images/hvm-instance/ubuntu-bionic-18.04-amd64-server-????????",
 	},
 	// 64 bit Microsoft Windows Server with Desktop Experience Locale English AMI
-	"Windows": map[string]string{
+	"Windows": {
 		"ebs": "Windows_Server-????-English-Full-Base-????.??.??",
 	},
 }
@@ -380,19 +380,19 @@ func getDescribeImagesInputs(rootDeviceType string) *map[string]ec2.DescribeImag
 		if found {
 			imageInputs[osName] = ec2.DescribeImagesInput{
 				Filters: []*ec2.Filter{
-					&ec2.Filter{
+					{
 						Name: aws.String("name"),
 						Values: []*string{
 							aws.String(desc),
 						},
 					},
-					&ec2.Filter{
+					{
 						Name: aws.String("state"),
 						Values: []*string{
 							aws.String("available"),
 						},
 					},
-					&ec2.Filter{
+					{
 						Name: aws.String("root-device-type"),
 						Values: []*string{
 							aws.String(rootDeviceType),
@@ -484,7 +484,7 @@ Empty result is not allowed.
 func (h *EC2Helper) GetImageById(imageId string) (*ec2.Image, error) {
 	input := &ec2.DescribeImagesInput{
 		Filters: []*ec2.Filter{
-			&ec2.Filter{
+			{
 				Name: aws.String("state"),
 				Values: []*string{
 					aws.String("available"),
@@ -733,16 +733,16 @@ func (h *EC2Helper) CreateSecurityGroupForSsh(vpcId string) (*string, error) {
 	ingressInput := &ec2.AuthorizeSecurityGroupIngressInput{
 		GroupId: aws.String(groupId),
 		IpPermissions: []*ec2.IpPermission{
-			&ec2.IpPermission{
+			{
 				FromPort:   aws.Int64(22),
 				IpProtocol: aws.String("tcp"),
 				IpRanges: []*ec2.IpRange{
-					&ec2.IpRange{
+					{
 						CidrIp: aws.String("0.0.0.0/0"),
 					},
 				},
 				Ipv6Ranges: []*ec2.Ipv6Range{
-					&ec2.Ipv6Range{
+					{
 						CidrIpv6: aws.String("::/0"),
 					},
 				},
@@ -1039,7 +1039,7 @@ func (h *EC2Helper) LaunchInstance(simpleConfig *config.SimpleInfo, detailedConf
 
 		// Add simple-ec2 tags to created resources
 		input.TagSpecifications = []*ec2.TagSpecification{
-			&ec2.TagSpecification{
+			{
 				ResourceType: aws.String("instance"),
 				Tags:         getSimpleEc2Tags(),
 			},

--- a/pkg/ec2helper/ec2helper_test.go
+++ b/pkg/ec2helper/ec2helper_test.go
@@ -18,9 +18,9 @@ import (
 	"os"
 	"testing"
 
-	"ez-ec2/pkg/config"
-	"ez-ec2/pkg/ec2helper"
-	th "ez-ec2/test/testhelper"
+	"simple-ec2/pkg/config"
+	"simple-ec2/pkg/ec2helper"
+	th "simple-ec2/test/testhelper"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -1396,7 +1396,7 @@ func TestGetTagName_Success(t *testing.T) {
 		},
 		&ec2.Tag{
 			Key:   aws.String("CreatedBy"),
-			Value: aws.String("ez-ec2"),
+			Value: aws.String("simple-ec2"),
 		},
 	}
 
@@ -1414,7 +1414,7 @@ func TestGetTagName_NoResult(t *testing.T) {
 		},
 		&ec2.Tag{
 			Key:   aws.String("CreatedBy"),
-			Value: aws.String("ez-ec2"),
+			Value: aws.String("simple-ec2"),
 		},
 	}
 

--- a/pkg/ec2helper/ec2helper_test.go
+++ b/pkg/ec2helper/ec2helper_test.go
@@ -87,10 +87,10 @@ func TestGetDefaultRegion_Default(t *testing.T) {
 
 func TestGetEnabledRegions_Success(t *testing.T) {
 	testRegions := []*ec2.Region{
-		&ec2.Region{
+		{
 			RegionName: aws.String("region-b"),
 		},
-		&ec2.Region{
+		{
 			RegionName: aws.String("region-a"),
 		},
 	}
@@ -133,10 +133,10 @@ Availability Zone Tests
 
 func TestGetAvailableAvailabilityZones_Success(t *testing.T) {
 	testZones := []*ec2.AvailabilityZone{
-		&ec2.AvailabilityZone{
+		{
 			ZoneName: aws.String("us-east-1a"),
 		},
-		&ec2.AvailabilityZone{
+		{
 			ZoneName: aws.String("us-east-1b"),
 		},
 	}
@@ -179,10 +179,10 @@ Launch Template Tests
 
 func TestGetLaunchTemplatesInRegion_Success(t *testing.T) {
 	testLaunchTemplates := []*ec2.LaunchTemplate{
-		&ec2.LaunchTemplate{
+		{
 			LaunchTemplateId: aws.String("lt-12345"),
 		},
-		&ec2.LaunchTemplate{
+		{
 			LaunchTemplateId: aws.String("lt-67890"),
 		},
 	}
@@ -223,10 +223,10 @@ const testLaunchTemplateId = "lt-12345"
 
 func TestGetLaunchTemplateById_Success(t *testing.T) {
 	testLaunchTemplates := []*ec2.LaunchTemplate{
-		&ec2.LaunchTemplate{
+		{
 			LaunchTemplateId: aws.String(testLaunchTemplateId),
 		},
-		&ec2.LaunchTemplate{
+		{
 			LaunchTemplateId: aws.String("lt-67890"),
 		},
 	}
@@ -271,11 +271,11 @@ Launch Template Version Tests
 
 func TestGetLaunchTemplateVersions_Success_AllVersions(t *testing.T) {
 	testLaunchTemplateVersions := []*ec2.LaunchTemplateVersion{
-		&ec2.LaunchTemplateVersion{
+		{
 			LaunchTemplateId: aws.String(testLaunchTemplateId),
 			VersionNumber:    aws.Int64(1),
 		},
-		&ec2.LaunchTemplateVersion{
+		{
 			LaunchTemplateId: aws.String(testLaunchTemplateId),
 			VersionNumber:    aws.Int64(2),
 		},
@@ -338,11 +338,11 @@ Instance Type Tests
 const freeInstanceType = "t2.micro"
 
 var testInstanceTypes = []*ec2.InstanceTypeInfo{
-	&ec2.InstanceTypeInfo{
+	{
 		InstanceType:     aws.String(freeInstanceType),
 		FreeTierEligible: aws.Bool(true),
 	},
-	&ec2.InstanceTypeInfo{
+	{
 		InstanceType:     aws.String("t2.nano"),
 		FreeTierEligible: aws.Bool(false),
 	},
@@ -459,10 +459,10 @@ Instance Selector Tests
 */
 
 var testInstanceTypeInfos = []*ec2.InstanceTypeInfo{
-	&ec2.InstanceTypeInfo{
+	{
 		InstanceType: aws.String("t2.micro"),
 	},
-	&ec2.InstanceTypeInfo{
+	{
 		InstanceType: aws.String("t2.nano"),
 	},
 }
@@ -514,7 +514,7 @@ var lastImage = &ec2.Image{
 	CreationDate: aws.String("1"),
 }
 var testImages = []*ec2.Image{
-	&ec2.Image{
+	{
 		ImageId:      aws.String("ami-12345"),
 		CreationDate: aws.String("0"),
 	},
@@ -653,10 +653,10 @@ VPC Tests
 */
 
 var testVpcs = []*ec2.Vpc{
-	&ec2.Vpc{
+	{
 		VpcId: aws.String("vpc-12345"),
 	},
-	&ec2.Vpc{
+	{
 		VpcId: aws.String("vpc-67890"),
 	},
 }
@@ -739,11 +739,11 @@ Subnet Tests
 func TestGetSubnetsByVpc_Success(t *testing.T) {
 	const testVpcId = "vpc-12345"
 	testSubnets := []*ec2.Subnet{
-		&ec2.Subnet{
+		{
 			SubnetId: aws.String("subnet-12345"),
 			VpcId:    aws.String(testVpcId),
 		},
-		&ec2.Subnet{
+		{
 			SubnetId: aws.String("subnet-67890"),
 			VpcId:    aws.String(testVpcId),
 		},
@@ -785,7 +785,7 @@ func TestGetSubnetsByVpc_NoResult(t *testing.T) {
 func TestGetSubnetById_Success(t *testing.T) {
 	const testSubnetId = "subnet-12345"
 	testSubnets := []*ec2.Subnet{
-		&ec2.Subnet{
+		{
 			SubnetId: aws.String(testSubnetId),
 		},
 	}
@@ -828,10 +828,10 @@ Security Group Tests
 */
 
 var testSecurityGroups = []*ec2.SecurityGroup{
-	&ec2.SecurityGroup{
+	{
 		GroupId: aws.String("sg-12345"),
 	},
-	&ec2.SecurityGroup{
+	{
 		GroupId: aws.String("sg-67890"),
 	},
 }
@@ -953,7 +953,7 @@ Instance Tests
 func TestGetInstanceById_Success(t *testing.T) {
 	const testInstanceId = ("i-12345")
 	testInstances := []*ec2.Instance{
-		&ec2.Instance{
+		{
 			InstanceId: aws.String(testInstanceId),
 		},
 	}
@@ -993,10 +993,10 @@ func TestGetInstanceById_NoResult(t *testing.T) {
 
 func TestGetInstancesByState_Success(t *testing.T) {
 	testInstances := []*ec2.Instance{
-		&ec2.Instance{
+		{
 			InstanceId: aws.String("i-12345"),
 		},
-		&ec2.Instance{
+		{
 			InstanceId: aws.String("i-67890"),
 		},
 	}
@@ -1045,31 +1045,31 @@ var testSimpleConfig = config.SimpleInfo{
 
 var parseConfigSvc = &th.MockedEC2Svc{
 	Subnets: []*ec2.Subnet{
-		&ec2.Subnet{
+		{
 			SubnetId: aws.String(testSubnetId),
 			VpcId:    aws.String(testVpcId),
 		},
 	},
 	Vpcs: []*ec2.Vpc{
-		&ec2.Vpc{
+		{
 			VpcId: aws.String(testVpcId),
 		},
 	},
 	Images: []*ec2.Image{
-		&ec2.Image{
+		{
 			ImageId: aws.String(testImageId),
 		},
 	},
 	InstanceTypes: []*ec2.InstanceTypeInfo{
-		&ec2.InstanceTypeInfo{
+		{
 			InstanceType: aws.String(testInstanceType),
 		},
 	},
 	SecurityGroups: []*ec2.SecurityGroup{
-		&ec2.SecurityGroup{
+		{
 			GroupId: aws.String(testSecurityGroupIds[0]),
 		},
-		&ec2.SecurityGroup{
+		{
 			GroupId: aws.String(testSecurityGroupIds[1]),
 		},
 	},
@@ -1143,34 +1143,34 @@ func TestParseConfig_DescribeSubnetsPagesError(t *testing.T) {
 
 var defaultConfigSvc = &th.MockedEC2Svc{
 	InstanceTypes: []*ec2.InstanceTypeInfo{
-		&ec2.InstanceTypeInfo{
+		{
 			InstanceType:             aws.String(testInstanceType),
 			FreeTierEligible:         aws.Bool(true),
 			InstanceStorageSupported: aws.Bool(true),
 		},
 	},
 	Images: []*ec2.Image{
-		&ec2.Image{
+		{
 			ImageId: aws.String(testImageId),
 		},
 	},
 	Vpcs: []*ec2.Vpc{
-		&ec2.Vpc{
+		{
 			VpcId:     aws.String(testVpcId),
 			IsDefault: aws.Bool(true),
 		},
 	},
 	Subnets: []*ec2.Subnet{
-		&ec2.Subnet{
+		{
 			SubnetId: aws.String(testSubnetId),
 			VpcId:    aws.String(testVpcId),
 		},
 	},
 	SecurityGroups: []*ec2.SecurityGroup{
-		&ec2.SecurityGroup{
+		{
 			GroupId: aws.String(testSecurityGroupIds[0]),
 		},
-		&ec2.SecurityGroup{
+		{
 			GroupId: aws.String(testSecurityGroupIds[1]),
 		},
 	},
@@ -1263,32 +1263,32 @@ Launch Tests
 
 var launchSvc = &th.MockedEC2Svc{
 	Subnets: []*ec2.Subnet{
-		&ec2.Subnet{
+		{
 			SubnetId: aws.String(testSubnetId),
 			VpcId:    aws.String(testVpcId),
 		},
 	},
 	Vpcs: []*ec2.Vpc{
-		&ec2.Vpc{
+		{
 			VpcId: aws.String(testVpcId),
 		},
 	},
 	Images: []*ec2.Image{
-		&ec2.Image{
+		{
 			ImageId:        aws.String(testImageId),
 			RootDeviceType: aws.String("ebs"),
 		},
 	},
 	InstanceTypes: []*ec2.InstanceTypeInfo{
-		&ec2.InstanceTypeInfo{
+		{
 			InstanceType: aws.String(testInstanceType),
 		},
 	},
 	SecurityGroups: []*ec2.SecurityGroup{
-		&ec2.SecurityGroup{
+		{
 			GroupId: aws.String(testSecurityGroupIds[0]),
 		},
-		&ec2.SecurityGroup{
+		{
 			GroupId: aws.String(testSecurityGroupIds[1]),
 		},
 	},
@@ -1297,7 +1297,7 @@ var launchSvc = &th.MockedEC2Svc{
 var testDetailedConfig = config.DetailedInfo{
 	Image: &ec2.Image{
 		BlockDeviceMappings: []*ec2.BlockDeviceMapping{
-			&ec2.BlockDeviceMapping{
+			{
 				Ebs: &ec2.EbsBlockDevice{},
 			},
 		},
@@ -1390,11 +1390,11 @@ Tag Tests
 func TestGetTagName_Success(t *testing.T) {
 	const testName = "Test Name"
 	testTags := []*ec2.Tag{
-		&ec2.Tag{
+		{
 			Key:   aws.String("Name"),
 			Value: aws.String(testName),
 		},
-		&ec2.Tag{
+		{
 			Key:   aws.String("CreatedBy"),
 			Value: aws.String("simple-ec2"),
 		},
@@ -1408,11 +1408,11 @@ func TestGetTagName_Success(t *testing.T) {
 
 func TestGetTagName_NoResult(t *testing.T) {
 	testTags := []*ec2.Tag{
-		&ec2.Tag{
+		{
 			Key:   aws.String("CreatedTime"),
 			Value: aws.String("012345"),
 		},
-		&ec2.Tag{
+		{
 			Key:   aws.String("CreatedBy"),
 			Value: aws.String("simple-ec2"),
 		},
@@ -1431,7 +1431,7 @@ Image Validation Tests
 func TestValidateImageId_True(t *testing.T) {
 	testEC2.Svc = &th.MockedEC2Svc{
 		Images: []*ec2.Image{
-			&ec2.Image{
+			{
 				ImageId: aws.String(testImageId),
 			},
 		},
@@ -1469,7 +1469,7 @@ func TestIsLinux_False(t *testing.T) {
 func TestHasEbsVolume_True(t *testing.T) {
 	testImage := &ec2.Image{
 		BlockDeviceMappings: []*ec2.BlockDeviceMapping{
-			&ec2.BlockDeviceMapping{
+			{
 				Ebs: &ec2.EbsBlockDevice{},
 			},
 		},
@@ -1483,7 +1483,7 @@ func TestHasEbsVolume_True(t *testing.T) {
 func TestHasEbsVolume_False(t *testing.T) {
 	testImage := &ec2.Image{
 		BlockDeviceMappings: []*ec2.BlockDeviceMapping{
-			&ec2.BlockDeviceMapping{},
+			{},
 		},
 	}
 

--- a/pkg/ec2instanceconnecthelper/ec2instanceconnecthelper.go
+++ b/pkg/ec2instanceconnecthelper/ec2instanceconnecthelper.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"os/exec"
 
-	"ez-ec2/pkg/config"
+	"simple-ec2/pkg/config"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -34,7 +34,7 @@ import (
 )
 
 const userName = "ec2-user"
-const passPhrase = "ez-ec2"
+const passPhrase = "simple-ec2"
 
 // Push an SSH key to an EC2 instance
 func SendSSHPublicKey(sess *session.Session, availabilityZone, instanceId,
@@ -88,9 +88,9 @@ func GenerateSSHKeyPair() (publicKeyString, privateKeyString *string, err error)
 // Establish an SSH connection to the instance
 func EstablishSSHConnection(privateKey, instanceDnsName string, exitAtOnce bool) error {
 	// Create the folder if it doesn't exist
-	ezec2Dir := os.Getenv("HOME") + "/.ez-ec2"
-	if _, err := os.Stat(ezec2Dir); os.IsNotExist(err) {
-		err = os.MkdirAll(ezec2Dir, os.ModePerm)
+	simpleEc2Dir := os.Getenv("HOME") + "/.simple-ec2"
+	if _, err := os.Stat(simpleEc2Dir); os.IsNotExist(err) {
+		err = os.MkdirAll(simpleEc2Dir, os.ModePerm)
 		if err != nil {
 			return err
 		}

--- a/pkg/ec2instanceconnecthelper/ec2instanceconnecthelper_test.go
+++ b/pkg/ec2instanceconnecthelper/ec2instanceconnecthelper_test.go
@@ -17,8 +17,8 @@ import (
 	"encoding/base64"
 	"testing"
 
-	ec2ichelper "ez-ec2/pkg/ec2instanceconnecthelper"
-	th "ez-ec2/test/testhelper"
+	ec2ichelper "simple-ec2/pkg/ec2instanceconnecthelper"
+	th "simple-ec2/test/testhelper"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"

--- a/pkg/ec2instanceconnecthelper/ec2instanceconnecthelper_test.go
+++ b/pkg/ec2instanceconnecthelper/ec2instanceconnecthelper_test.go
@@ -59,7 +59,7 @@ func TestGetInstancePublicDnsName_Success(t *testing.T) {
 	const testDnsName = "test dns name"
 	instance := &ec2.Instance{
 		NetworkInterfaces: []*ec2.InstanceNetworkInterface{
-			&ec2.InstanceNetworkInterface{
+			{
 				Association: &ec2.InstanceNetworkInterfaceAssociation{
 					PublicDnsName: aws.String(testDnsName),
 				},
@@ -89,7 +89,7 @@ func TestGetInstancePublicDnsName_NoNetworkInterface(t *testing.T) {
 func TestGetInstancePublicDnsName_NoDnsNameInNetworkInterface(t *testing.T) {
 	instance := &ec2.Instance{
 		NetworkInterfaces: []*ec2.InstanceNetworkInterface{
-			&ec2.InstanceNetworkInterface{
+			{
 				Association: &ec2.InstanceNetworkInterfaceAssociation{},
 			},
 		},

--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -847,11 +847,11 @@ func AskConfirmationWithInput(simpleConfig *config.SimpleInfo, detailedConfig *c
 
 	// Get display data ready
 	data := [][]string{
-		[]string{cli.ResourceRegion, simpleConfig.Region},
-		[]string{cli.ResourceVpc, vpcInfo},
-		[]string{cli.ResourceSubnet, subnetInfo},
-		[]string{cli.ResourceInstanceType, simpleConfig.InstanceType},
-		[]string{cli.ResourceImage, simpleConfig.ImageId},
+		{cli.ResourceRegion, simpleConfig.Region},
+		{cli.ResourceVpc, vpcInfo},
+		{cli.ResourceSubnet, subnetInfo},
+		{cli.ResourceInstanceType, simpleConfig.InstanceType},
+		{cli.ResourceImage, simpleConfig.ImageId},
 	}
 
 	indexedOptions := []string{}

--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -21,11 +21,11 @@ import (
 	"strconv"
 	"strings"
 
-	"ez-ec2/pkg/cfn"
-	"ez-ec2/pkg/cli"
-	"ez-ec2/pkg/config"
-	"ez-ec2/pkg/ec2helper"
-	"ez-ec2/pkg/table"
+	"simple-ec2/pkg/cfn"
+	"simple-ec2/pkg/cli"
+	"simple-ec2/pkg/config"
+	"simple-ec2/pkg/ec2helper"
+	"simple-ec2/pkg/table"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/endpoints"

--- a/pkg/question/question_test.go
+++ b/pkg/question/question_test.go
@@ -18,11 +18,11 @@ import (
 	"strconv"
 	"testing"
 
-	"ez-ec2/pkg/cli"
-	"ez-ec2/pkg/config"
-	"ez-ec2/pkg/ec2helper"
-	"ez-ec2/pkg/question"
-	th "ez-ec2/test/testhelper"
+	"simple-ec2/pkg/cli"
+	"simple-ec2/pkg/config"
+	"simple-ec2/pkg/ec2helper"
+	"simple-ec2/pkg/question"
+	th "simple-ec2/test/testhelper"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"

--- a/pkg/question/question_test.go
+++ b/pkg/question/question_test.go
@@ -125,7 +125,7 @@ func TestAskQuestion_FunctionCheckedInput(t *testing.T) {
 	testEC2 := &ec2helper.EC2Helper{
 		Svc: &th.MockedEC2Svc{
 			Images: []*ec2.Image{
-				&ec2.Image{
+				{
 					ImageId: aws.String(testImageId),
 				},
 			},
@@ -156,13 +156,13 @@ func TestAskRegion_Success(t *testing.T) {
 
 	testEC2.Svc = &th.MockedEC2Svc{
 		Regions: []*ec2.Region{
-			&ec2.Region{
+			{
 				RegionName: aws.String(testRegion),
 			},
-			&ec2.Region{
+			{
 				RegionName: aws.String("us-west-1"),
 			},
-			&ec2.Region{
+			{
 				RegionName: aws.String("us-west-2"),
 			},
 		},
@@ -199,12 +199,12 @@ func TestAskLaunchTemplate_Success(t *testing.T) {
 
 	testEC2.Svc = &th.MockedEC2Svc{
 		LaunchTemplates: []*ec2.LaunchTemplate{
-			&ec2.LaunchTemplate{
+			{
 				LaunchTemplateId:    aws.String(testTemplateId),
 				LaunchTemplateName:  aws.String(testTemplateId),
 				LatestVersionNumber: aws.Int64(1),
 			},
-			&ec2.LaunchTemplate{
+			{
 				LaunchTemplateId:    aws.String("lt-67890"),
 				LaunchTemplateName:  aws.String("lt-67890"),
 				LatestVersionNumber: aws.Int64(1),
@@ -242,13 +242,13 @@ func TestAskLaunchTemplateVersion_Success(t *testing.T) {
 
 	testEC2.Svc = &th.MockedEC2Svc{
 		LaunchTemplateVersions: []*ec2.LaunchTemplateVersion{
-			&ec2.LaunchTemplateVersion{
+			{
 				LaunchTemplateId:   aws.String(testTemplateId),
 				VersionDescription: aws.String("description"),
 				VersionNumber:      aws.Int64(testVersion),
 				DefaultVersion:     aws.Bool(true),
 			},
-			&ec2.LaunchTemplateVersion{
+			{
 				LaunchTemplateId: aws.String(testTemplateId),
 				VersionNumber:    aws.Int64(2),
 				DefaultVersion:   aws.Bool(false),
@@ -289,7 +289,7 @@ func TestAskIfEnterInstanceType_Success(t *testing.T) {
 
 	testEC2.Svc = &th.MockedEC2Svc{
 		InstanceTypes: []*ec2.InstanceTypeInfo{
-			&ec2.InstanceTypeInfo{
+			{
 				InstanceType:     aws.String(testInstanceType),
 				FreeTierEligible: aws.Bool(true),
 			},
@@ -327,7 +327,7 @@ func TestAskInstanceType_Success(t *testing.T) {
 
 	testEC2.Svc = &th.MockedEC2Svc{
 		InstanceTypes: []*ec2.InstanceTypeInfo{
-			&ec2.InstanceTypeInfo{
+			{
 				InstanceType:     aws.String(testInstanceType),
 				FreeTierEligible: aws.Bool(true),
 			},
@@ -390,13 +390,13 @@ func TestAskImage_Success(t *testing.T) {
 
 	testEC2.Svc = &th.MockedEC2Svc{
 		InstanceTypes: []*ec2.InstanceTypeInfo{
-			&ec2.InstanceTypeInfo{
+			{
 				InstanceType:             aws.String(testInstanceType),
 				InstanceStorageSupported: aws.Bool(true),
 			},
 		},
 		Images: []*ec2.Image{
-			&ec2.Image{
+			{
 				ImageId:      aws.String(testImage),
 				CreationDate: aws.String("some time"),
 			},
@@ -419,7 +419,7 @@ func TestAskImage_NoImage(t *testing.T) {
 
 	testEC2.Svc = &th.MockedEC2Svc{
 		InstanceTypes: []*ec2.InstanceTypeInfo{
-			&ec2.InstanceTypeInfo{
+			{
 				InstanceType:             aws.String(testInstanceType),
 				InstanceStorageSupported: aws.Bool(true),
 			},
@@ -456,7 +456,7 @@ func TestAskImage_DescribeImagesError(t *testing.T) {
 
 	testEC2.Svc = &th.MockedEC2Svc{
 		InstanceTypes: []*ec2.InstanceTypeInfo{
-			&ec2.InstanceTypeInfo{
+			{
 				InstanceType:             aws.String(testInstanceType),
 				InstanceStorageSupported: aws.Bool(true),
 			},
@@ -502,18 +502,18 @@ func TestAskVpc_Success(t *testing.T) {
 
 	testEC2.Svc = &th.MockedEC2Svc{
 		Vpcs: []*ec2.Vpc{
-			&ec2.Vpc{
+			{
 				VpcId:     aws.String(testVpc),
 				CidrBlock: aws.String("some block"),
 				Tags: []*ec2.Tag{
-					&ec2.Tag{
+					{
 						Key:   aws.String("Name"),
 						Value: aws.String("test vpc"),
 					},
 				},
 				IsDefault: aws.Bool(true),
 			},
-			&ec2.Vpc{
+			{
 				VpcId:     aws.String("vpc-67890"),
 				CidrBlock: aws.String("some block"),
 				IsDefault: aws.Bool(false),
@@ -554,19 +554,19 @@ func TestAskSubnet_Success(t *testing.T) {
 
 	testEC2.Svc = &th.MockedEC2Svc{
 		Subnets: []*ec2.Subnet{
-			&ec2.Subnet{
+			{
 				SubnetId:         aws.String(testSubnet),
 				VpcId:            aws.String(testVpc),
 				CidrBlock:        aws.String("some block"),
 				AvailabilityZone: aws.String("some az"),
 				Tags: []*ec2.Tag{
-					&ec2.Tag{
+					{
 						Key:   aws.String("Name"),
 						Value: aws.String("test subnet"),
 					},
 				},
 			},
-			&ec2.Subnet{
+			{
 				SubnetId:         aws.String("subnet-67890"),
 				VpcId:            aws.String(testVpc),
 				CidrBlock:        aws.String("some block"),
@@ -607,11 +607,11 @@ func TestAskSubnetPlaceholder_Success(t *testing.T) {
 
 	testEC2.Svc = &th.MockedEC2Svc{
 		AvailabilityZones: []*ec2.AvailabilityZone{
-			&ec2.AvailabilityZone{
+			{
 				ZoneName: aws.String(testAz),
 				ZoneId:   aws.String("some id"),
 			},
-			&ec2.AvailabilityZone{
+			{
 				ZoneName: aws.String("us-east-2"),
 				ZoneId:   aws.String("some id"),
 			},
@@ -648,30 +648,30 @@ func TestAskSecurityGroups_Success(t *testing.T) {
 	const testGroup = "sg-12345"
 
 	testSecurityGroups := []*ec2.SecurityGroup{
-		&ec2.SecurityGroup{
+		{
 			GroupId: aws.String(testGroup),
 			Tags: []*ec2.Tag{
-				&ec2.Tag{
+				{
 					Key:   aws.String("Name"),
 					Value: aws.String("test group"),
 				},
 			},
 			Description: aws.String("some description"),
 		},
-		&ec2.SecurityGroup{
+		{
 			GroupId: aws.String("sg-67890"),
 			Tags: []*ec2.Tag{
-				&ec2.Tag{
+				{
 					Key:   aws.String("Name"),
 					Value: aws.String("test group"),
 				},
 			},
 			Description: aws.String("some description"),
 		},
-		&ec2.SecurityGroup{
+		{
 			GroupId: aws.String("sg-67890"),
 			Tags: []*ec2.Tag{
-				&ec2.Tag{
+				{
 					Key:   aws.String("Name"),
 					Value: aws.String("test group"),
 				},
@@ -726,7 +726,7 @@ func TestAskComfirmationWithTemplate_Success_NoOverriding(t *testing.T) {
 
 	testEC2.Svc = &th.MockedEC2Svc{
 		LaunchTemplateVersions: []*ec2.LaunchTemplateVersion{
-			&ec2.LaunchTemplateVersion{
+			{
 				LaunchTemplateId: aws.String(testTemplateId),
 				VersionNumber:    aws.Int64(testVersion),
 				LaunchTemplateData: &ec2.ResponseLaunchTemplateData{
@@ -761,7 +761,7 @@ func TestAskComfirmationWithTemplate_Success_Overriding(t *testing.T) {
 
 	testEC2.Svc = &th.MockedEC2Svc{
 		LaunchTemplateVersions: []*ec2.LaunchTemplateVersion{
-			&ec2.LaunchTemplateVersion{
+			{
 				LaunchTemplateId: aws.String(testTemplateId),
 				VersionNumber:    aws.Int64(testVersion),
 				LaunchTemplateData: &ec2.ResponseLaunchTemplateData{
@@ -798,14 +798,14 @@ func TestAskComfirmationWithTemplate_DescribeSubnetsPagesError(t *testing.T) {
 
 	testEC2.Svc = &th.MockedEC2Svc{
 		LaunchTemplateVersions: []*ec2.LaunchTemplateVersion{
-			&ec2.LaunchTemplateVersion{
+			{
 				LaunchTemplateId: aws.String(testTemplateId),
 				VersionNumber:    aws.Int64(testVersion),
 				LaunchTemplateData: &ec2.ResponseLaunchTemplateData{
 					ImageId:      aws.String("ami-12345"),
 					InstanceType: aws.String(ec2.InstanceTypeT2Micro),
 					NetworkInterfaces: []*ec2.LaunchTemplateInstanceNetworkInterfaceSpecification{
-						&ec2.LaunchTemplateInstanceNetworkInterfaceSpecification{
+						{
 							SubnetId: aws.String("subnet-12345"),
 						},
 					},
@@ -865,7 +865,7 @@ var testDetailedConfig = &config.DetailedInfo{
 	Image: &ec2.Image{
 		ImageId: aws.String(testSimpleConfig.ImageId),
 		BlockDeviceMappings: []*ec2.BlockDeviceMapping{
-			&ec2.BlockDeviceMapping{
+			{
 				DeviceName: aws.String("device 1"),
 				Ebs: &ec2.EbsBlockDevice{
 					VolumeType: aws.String("gp2"),
@@ -884,7 +884,7 @@ var testDetailedConfig = &config.DetailedInfo{
 	Subnet: &ec2.Subnet{
 		SubnetId: aws.String(testSimpleConfig.SubnetId),
 		Tags: []*ec2.Tag{
-			&ec2.Tag{
+			{
 				Key:   aws.String("Name"),
 				Value: aws.String("test subnet"),
 			},
@@ -893,14 +893,14 @@ var testDetailedConfig = &config.DetailedInfo{
 	Vpc: &ec2.Vpc{
 		VpcId: aws.String("vpc-12345"),
 		Tags: []*ec2.Tag{
-			&ec2.Tag{
+			{
 				Key:   aws.String("Name"),
 				Value: aws.String("test vpc"),
 			},
 		},
 	},
 	SecurityGroups: []*ec2.SecurityGroup{
-		&ec2.SecurityGroup{
+		{
 			GroupId: aws.String(testSimpleConfig.SecurityGroupIds[0]),
 		},
 	},
@@ -956,10 +956,10 @@ func TestAskInstanceId_Success(t *testing.T) {
 
 	testEC2.Svc = &th.MockedEC2Svc{
 		Instances: []*ec2.Instance{
-			&ec2.Instance{
+			{
 				InstanceId: aws.String(testInstance),
 			},
-			&ec2.Instance{
+			{
 				InstanceId: aws.String("i-67890"),
 			},
 		},
@@ -1012,10 +1012,10 @@ func TestAskInstanceIds_Success(t *testing.T) {
 
 	testEC2.Svc = &th.MockedEC2Svc{
 		Instances: []*ec2.Instance{
-			&ec2.Instance{
+			{
 				InstanceId: aws.String(testInstance),
 			},
-			&ec2.Instance{
+			{
 				InstanceId: aws.String("i-67890"),
 			},
 		},
@@ -1071,7 +1071,7 @@ Instance Selector Question Tests
 const testInstanceType = ec2.InstanceTypeT2Micro
 
 var testInstanceTypeInfos = []*ec2.InstanceTypeInfo{
-	&ec2.InstanceTypeInfo{
+	{
 		InstanceType: aws.String(testInstanceType),
 		VCpuInfo: &ec2.VCpuInfo{
 			DefaultVCpus: aws.Int64(2),
@@ -1081,7 +1081,7 @@ var testInstanceTypeInfos = []*ec2.InstanceTypeInfo{
 		},
 		InstanceStorageSupported: aws.Bool(false),
 	},
-	&ec2.InstanceTypeInfo{
+	{
 		InstanceType: aws.String("t2.nano"),
 		VCpuInfo: &ec2.VCpuInfo{
 			DefaultVCpus: aws.Int64(1),

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -18,8 +18,8 @@ import (
 	"sort"
 	"strings"
 
-	"ez-ec2/pkg/cli"
-	"ez-ec2/pkg/ec2helper"
+	"simple-ec2/pkg/cli"
+	"simple-ec2/pkg/ec2helper"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/olekukonko/tablewriter"

--- a/pkg/table/table_test.go
+++ b/pkg/table/table_test.go
@@ -38,9 +38,9 @@ func TestBuildTable(t *testing.T) {
 `
 
 	data := [][]string{
-		[]string{"Row 1", "Element 1", "Element 2"},
-		[]string{"Row 2", "Element 3", "Element 4"},
-		[]string{"Row 3", "Element 5", "Element 6"},
+		{"Row 1", "Element 1", "Element 2"},
+		{"Row 2", "Element 3", "Element 4"},
+		{"Row 3", "Element 5", "Element 6"},
 	}
 
 	header := []string{"Row Num", "Elements 1", "Elements 2"}
@@ -55,35 +55,35 @@ func TestBuildTable(t *testing.T) {
 
 func TestAppendTemplateEbs(t *testing.T) {
 	correctData := [][]string{
-		[]string{"EBS Volumes", "dev1(gp2): 16 GiB"},
-		[]string{"", "dev2(gp2)"},
-		[]string{"", "dev3: 32 GiB"},
-		[]string{"", "dev4"},
+		{"EBS Volumes", "dev1(gp2): 16 GiB"},
+		{"", "dev2(gp2)"},
+		{"", "dev3: 32 GiB"},
+		{"", "dev4"},
 	}
 
 	data := [][]string{}
 
 	mappings := []*ec2.LaunchTemplateBlockDeviceMapping{
-		&ec2.LaunchTemplateBlockDeviceMapping{
+		{
 			DeviceName: aws.String("dev1"),
 			Ebs: &ec2.LaunchTemplateEbsBlockDevice{
 				VolumeType: aws.String("gp2"),
 				VolumeSize: aws.Int64(16),
 			},
 		},
-		&ec2.LaunchTemplateBlockDeviceMapping{
+		{
 			DeviceName: aws.String("dev2"),
 			Ebs: &ec2.LaunchTemplateEbsBlockDevice{
 				VolumeType: aws.String("gp2"),
 			},
 		},
-		&ec2.LaunchTemplateBlockDeviceMapping{
+		{
 			DeviceName: aws.String("dev3"),
 			Ebs: &ec2.LaunchTemplateEbsBlockDevice{
 				VolumeSize: aws.Int64(32),
 			},
 		},
-		&ec2.LaunchTemplateBlockDeviceMapping{
+		{
 			DeviceName: aws.String("dev4"),
 		},
 	}
@@ -101,35 +101,35 @@ func TestAppendTemplateEbs(t *testing.T) {
 
 func TestAppendEbs(t *testing.T) {
 	correctData := [][]string{
-		[]string{"EBS Volumes", "dev1(gp2): 16 GiB"},
-		[]string{"", "dev2(gp2)"},
-		[]string{"", "dev3: 32 GiB"},
-		[]string{"", "dev4"},
+		{"EBS Volumes", "dev1(gp2): 16 GiB"},
+		{"", "dev2(gp2)"},
+		{"", "dev3: 32 GiB"},
+		{"", "dev4"},
 	}
 
 	data := [][]string{}
 
 	mappings := []*ec2.BlockDeviceMapping{
-		&ec2.BlockDeviceMapping{
+		{
 			DeviceName: aws.String("dev1"),
 			Ebs: &ec2.EbsBlockDevice{
 				VolumeType: aws.String("gp2"),
 				VolumeSize: aws.Int64(16),
 			},
 		},
-		&ec2.BlockDeviceMapping{
+		{
 			DeviceName: aws.String("dev2"),
 			Ebs: &ec2.EbsBlockDevice{
 				VolumeType: aws.String("gp2"),
 			},
 		},
-		&ec2.BlockDeviceMapping{
+		{
 			DeviceName: aws.String("dev3"),
 			Ebs: &ec2.EbsBlockDevice{
 				VolumeSize: aws.Int64(32),
 			},
 		},
-		&ec2.BlockDeviceMapping{
+		{
 			DeviceName: aws.String("dev4"),
 		},
 	}
@@ -147,23 +147,23 @@ func TestAppendEbs(t *testing.T) {
 
 func TestAppendSecurityGroups(t *testing.T) {
 	correctData := [][]string{
-		[]string{"Security Group", "Security Group 1(sg-12345)"},
-		[]string{"", "sg-67890"},
+		{"Security Group", "Security Group 1(sg-12345)"},
+		{"", "sg-67890"},
 	}
 
 	data := [][]string{}
 
 	securityGroups := []*ec2.SecurityGroup{
-		&ec2.SecurityGroup{
+		{
 			GroupId: aws.String("sg-12345"),
 			Tags: []*ec2.Tag{
-				&ec2.Tag{
+				{
 					Key:   aws.String("Name"),
 					Value: aws.String("Security Group 1"),
 				},
 			},
 		},
-		&ec2.SecurityGroup{
+		{
 			GroupId: aws.String("sg-67890"),
 		},
 	}
@@ -180,35 +180,35 @@ func TestAppendSecurityGroups(t *testing.T) {
 }
 
 var mockedNetworkInterfaces = []*ec2.LaunchTemplateInstanceNetworkInterfaceSpecification{
-	&ec2.LaunchTemplateInstanceNetworkInterfaceSpecification{
+	{
 		SubnetId: aws.String("subnet-12345"),
 	},
-	&ec2.LaunchTemplateInstanceNetworkInterfaceSpecification{
+	{
 		SubnetId: aws.String("subnet-67890"),
 	},
 }
 
 func TestAppendTemplateNetworkInterfaces_Success(t *testing.T) {
 	correctData := [][]string{
-		[]string{"Subnets", "1.Subnet 1(vpc-12345:subnet-12345)"},
-		[]string{"", "2.vpc-67890:subnet-67890"},
+		{"Subnets", "1.Subnet 1(vpc-12345:subnet-12345)"},
+		{"", "2.vpc-67890:subnet-67890"},
 	}
 
 	data := [][]string{}
 
 	testEC2.Svc = &th.MockedEC2Svc{
 		Subnets: []*ec2.Subnet{
-			&ec2.Subnet{
+			{
 				SubnetId: aws.String("subnet-12345"),
 				VpcId:    aws.String("vpc-12345"),
 				Tags: []*ec2.Tag{
-					&ec2.Tag{
+					{
 						Key:   aws.String("Name"),
 						Value: aws.String("Subnet 1"),
 					},
 				},
 			},
-			&ec2.Subnet{
+			{
 				SubnetId: aws.String("subnet-67890"),
 				VpcId:    aws.String("vpc-67890"),
 			},
@@ -232,7 +232,7 @@ func TestAppendTemplateNetworkInterfaces_Success(t *testing.T) {
 
 func TestAppendTemplateNetworkInterfaces_NoNetworkInterface(t *testing.T) {
 	correctData := [][]string{
-		[]string{"Subnets", "not specified"},
+		{"Subnets", "not specified"},
 	}
 	data := [][]string{}
 
@@ -266,10 +266,10 @@ func TestAppendTemplateNetworkInterfaces_ApiError(t *testing.T) {
 
 func TestAppendInstances(t *testing.T) {
 	correctData := [][]string{
-		[]string{"1.", "Instance 2(i-67890)", "", ""},
-		[]string{"2.", "Instance 3(i-54321)", "CreatedBy", "simple-ec2"},
-		[]string{"", "", "CreatedTime", "just now"},
-		[]string{"3.", "i-09876", "", ""},
+		{"1.", "Instance 2(i-67890)", "", ""},
+		{"2.", "Instance 3(i-54321)", "CreatedBy", "simple-ec2"},
+		{"", "", "CreatedTime", "just now"},
+		{"3.", "i-09876", "", ""},
 	}
 	correctOptions := []string{
 		"i-67890",
@@ -282,42 +282,42 @@ func TestAppendInstances(t *testing.T) {
 	addedInstanceIds := []string{}
 
 	instances := []*ec2.Instance{
-		&ec2.Instance{
+		{
 			InstanceId: aws.String("i-12345"),
 			Tags: []*ec2.Tag{
-				&ec2.Tag{
+				{
 					Key:   aws.String("Name"),
 					Value: aws.String("Instance 1"),
 				},
 			},
 		},
-		&ec2.Instance{
+		{
 			InstanceId: aws.String("i-67890"),
 			Tags: []*ec2.Tag{
-				&ec2.Tag{
+				{
 					Key:   aws.String("Name"),
 					Value: aws.String("Instance 2"),
 				},
 			},
 		},
-		&ec2.Instance{
+		{
 			InstanceId: aws.String("i-54321"),
 			Tags: []*ec2.Tag{
-				&ec2.Tag{
+				{
 					Key:   aws.String("Name"),
 					Value: aws.String("Instance 3"),
 				},
-				&ec2.Tag{
+				{
 					Key:   aws.String("CreatedBy"),
 					Value: aws.String("simple-ec2"),
 				},
-				&ec2.Tag{
+				{
 					Key:   aws.String("CreatedTime"),
 					Value: aws.String("just now"),
 				},
 			},
 		},
-		&ec2.Instance{
+		{
 			InstanceId: aws.String("i-09876"),
 		},
 	}

--- a/pkg/table/table_test.go
+++ b/pkg/table/table_test.go
@@ -17,9 +17,9 @@ import (
 	"errors"
 	"testing"
 
-	"ez-ec2/pkg/ec2helper"
-	"ez-ec2/pkg/table"
-	th "ez-ec2/test/testhelper"
+	"simple-ec2/pkg/ec2helper"
+	"simple-ec2/pkg/table"
+	th "simple-ec2/test/testhelper"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -267,7 +267,7 @@ func TestAppendTemplateNetworkInterfaces_ApiError(t *testing.T) {
 func TestAppendInstances(t *testing.T) {
 	correctData := [][]string{
 		[]string{"1.", "Instance 2(i-67890)", "", ""},
-		[]string{"2.", "Instance 3(i-54321)", "CreatedBy", "ez-ec2"},
+		[]string{"2.", "Instance 3(i-54321)", "CreatedBy", "simple-ec2"},
 		[]string{"", "", "CreatedTime", "just now"},
 		[]string{"3.", "i-09876", "", ""},
 	}
@@ -309,7 +309,7 @@ func TestAppendInstances(t *testing.T) {
 				},
 				&ec2.Tag{
 					Key:   aws.String("CreatedBy"),
-					Value: aws.String("ez-ec2"),
+					Value: aws.String("simple-ec2"),
 				},
 				&ec2.Tag{
 					Key:   aws.String("CreatedTime"),

--- a/pkg/tag/tag.go
+++ b/pkg/tag/tag.go
@@ -18,7 +18,7 @@ import (
 	"time"
 )
 
-// Get the tags for resources created by ez-ec2
+// Get the tags for resources created by simple-ec2
 func GetTags() *map[string]string {
 	now := time.Now()
 	zone, _ := now.Zone()
@@ -26,7 +26,7 @@ func GetTags() *map[string]string {
 		now.Second(), zone)
 
 	tags := map[string]string{
-		"CreatedBy":   "ez-ec2",
+		"CreatedBy":   "simple-ec2",
 		"CreatedTime": nowString,
 	}
 

--- a/pkg/tag/tag_test.go
+++ b/pkg/tag/tag_test.go
@@ -16,14 +16,14 @@ package tag_test
 import (
 	"testing"
 
-	"ez-ec2/pkg/tag"
+	"simple-ec2/pkg/tag"
 )
 
 func TestGetTags(t *testing.T) {
 	tags := tag.GetTags()
 
 	createdBy, found := (*tags)["CreatedBy"]
-	if !found || createdBy != "ez-ec2" {
+	if !found || createdBy != "simple-ec2" {
 		t.Error("CreatedBy tag is not created correctly")
 	}
 

--- a/scripts/build-binaries
+++ b/scripts/build-binaries
@@ -48,13 +48,13 @@ for os_arch in "${PLATFORMS[@]}"; do
     arch=$(echo $os_arch | cut -d'/' -f2)
     container_name="extract-aeis-$os-$arch"
     repo_name="aeis-bin"
-    base_bin_name="ez-ec2"
+    base_bin_name="simple-ec2"
     bin_name="${base_bin_name}-${os}-${arch}"
 
     docker container rm $container_name || :
     $SCRIPTPATH/build-docker-images -p $os_arch -v $VERSION -r $repo_name $PASS_THRU_ARGS
     docker container create --rm --name $container_name "$repo_name:$VERSION-$os-$arch"
-    docker container cp $container_name:/ez-ec2 $BIN_DIR/$bin_name
+    docker container cp $container_name:/simple-ec2 $BIN_DIR/$bin_name
 
     cp ${BIN_DIR}/${bin_name} ${BIN_DIR}/${base_bin_name}
     tar -zcvf ${BIN_DIR}/${bin_name}.tar.gz -C ${BIN_DIR} ${base_bin_name}

--- a/test/e2e/e2e-cfn-test/cloudformation_template.json
+++ b/test/e2e/e2e-cfn-test/cloudformation_template.json
@@ -9,7 +9,7 @@
                 "Tags": [
                     {
                         "Key": "Name",
-                        "Value": "ez-ec2 VPC"
+                        "Value": "simple-ec2 VPC"
                     }
                 ]
             }
@@ -25,7 +25,7 @@
                 "Tags": [
                     {
                         "Key": "Name",
-                        "Value": "ez-ec2 Subnet"
+                        "Value": "simple-ec2 Subnet"
                     }
                 ],
                 "VpcId": {
@@ -44,7 +44,7 @@
                 "Tags": [
                     {
                         "Key": "Name",
-                        "Value": "ez-ec2 Subnet"
+                        "Value": "simple-ec2 Subnet"
                     }
                 ],
                 "VpcId": {
@@ -63,7 +63,7 @@
                 "Tags": [
                     {
                         "Key": "Name",
-                        "Value": "ez-ec2 Subnet"
+                        "Value": "simple-ec2 Subnet"
                     }
                 ],
                 "VpcId": {

--- a/test/e2e/e2e-cfn-test/e2e_cfn_test.go
+++ b/test/e2e/e2e-cfn-test/e2e_cfn_test.go
@@ -4,14 +4,14 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"testing"
 
-	"ez-ec2/pkg/cfn"
+	"simple-ec2/pkg/cfn"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 )
 
-const testStackName = "ez-ec2-e2e-cfn-test"
+const testStackName = "simple-ec2-e2e-cfn-test"
 const correctRegion = "us-east-2"
 
 var sess = session.Must(session.NewSessionWithOptions(session.Options{SharedConfigState: session.SharedConfigEnable}))

--- a/test/e2e/e2e-cfn-test/e2e_cfn_test.go
+++ b/test/e2e/e2e-cfn-test/e2e_cfn_test.go
@@ -1,8 +1,9 @@
 package cfn_e2e
 
 import (
-	"github.com/aws/aws-sdk-go/service/ec2"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
 
 	"simple-ec2/pkg/cfn"
 
@@ -17,13 +18,13 @@ const correctRegion = "us-east-2"
 var sess = session.Must(session.NewSessionWithOptions(session.Options{SharedConfigState: session.SharedConfigEnable}))
 var c = cfn.New(sess)
 var testAvailabilityZones = []*ec2.AvailabilityZone{
-	&ec2.AvailabilityZone{
+	{
 		ZoneName: aws.String("us-east-2a"),
 	},
-	&ec2.AvailabilityZone{
+	{
 		ZoneName: aws.String("us-east-2b"),
 	},
-	&ec2.AvailabilityZone{
+	{
 		ZoneName: aws.String("us-east-2c"),
 	},
 }

--- a/test/e2e/e2e-connect-test/cloudformation_template.json
+++ b/test/e2e/e2e-connect-test/cloudformation_template.json
@@ -9,7 +9,7 @@
                 "Tags": [
                     {
                         "Key": "Name",
-                        "Value": "ez-ec2 VPC"
+                        "Value": "simple-ec2 VPC"
                     }
                 ]
             }
@@ -23,7 +23,7 @@
                 "Tags": [
                     {
                         "Key": "Name",
-                        "Value": "ez-ec2 Subnet"
+                        "Value": "simple-ec2 Subnet"
                     }
                 ],
                 "VpcId": {

--- a/test/e2e/e2e-connect-test/e2e_connect_test.go
+++ b/test/e2e/e2e-connect-test/e2e_connect_test.go
@@ -17,16 +17,16 @@ import (
 	"testing"
 	"time"
 
-	"ez-ec2/pkg/cfn"
-	"ez-ec2/pkg/ec2helper"
-	ec2ichelper "ez-ec2/pkg/ec2instanceconnecthelper"
+	"simple-ec2/pkg/cfn"
+	"simple-ec2/pkg/ec2helper"
+	ec2ichelper "simple-ec2/pkg/ec2instanceconnecthelper"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 )
 
-const testStackName = "ez-ec2-e2e-connect-test"
+const testStackName = "simple-ec2-e2e-connect-test"
 const correctRegion = "us-east-2"
 const availabilityZone = "us-east-2a"
 

--- a/test/e2e/e2e-ec2helper-test/cloudformation_template.json
+++ b/test/e2e/e2e-ec2helper-test/cloudformation_template.json
@@ -9,7 +9,7 @@
                 "Tags": [
                     {
                         "Key": "Name",
-                        "Value": "ez-ec2 VPC"
+                        "Value": "simple-ec2 VPC"
                     }
                 ]
             }
@@ -23,7 +23,7 @@
                 "Tags": [
                     {
                         "Key": "Name",
-                        "Value": "ez-ec2 Subnet"
+                        "Value": "simple-ec2 Subnet"
                     }
                 ],
                 "VpcId": {

--- a/test/e2e/e2e-ec2helper-test/e2e_ec2helper_test.go
+++ b/test/e2e/e2e-ec2helper-test/e2e_ec2helper_test.go
@@ -14,8 +14,9 @@
 package ec2helper_e2e
 
 import (
-	"github.com/aws/aws-sdk-go/service/ec2"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
 
 	"simple-ec2/pkg/cfn"
 	"simple-ec2/pkg/config"

--- a/test/e2e/e2e-ec2helper-test/e2e_ec2helper_test.go
+++ b/test/e2e/e2e-ec2helper-test/e2e_ec2helper_test.go
@@ -17,10 +17,10 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"testing"
 
-	"ez-ec2/pkg/cfn"
-	"ez-ec2/pkg/config"
-	"ez-ec2/pkg/ec2helper"
-	th "ez-ec2/test/testhelper"
+	"simple-ec2/pkg/cfn"
+	"simple-ec2/pkg/config"
+	"simple-ec2/pkg/ec2helper"
+	th "simple-ec2/test/testhelper"
 
 	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector"
 	"github.com/aws/aws-sdk-go/aws"
@@ -28,7 +28,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 )
 
-const testStackName = "ez-ec2-e2e-ec2helper-test"
+const testStackName = "simple-ec2-e2e-ec2helper-test"
 const correctRegion = "us-east-2"
 const testAmi = "ami-026dea5602e368e96"
 

--- a/test/manual.go
+++ b/test/manual.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
-	"ez-ec2/pkg/cli"
-	th "ez-ec2/test/testhelper"
+	"simple-ec2/pkg/cli"
+	th "simple-ec2/test/testhelper"
 )
 
 func main() {

--- a/test/testhelper/ec2helper_mock.go
+++ b/test/testhelper/ec2helper_mock.go
@@ -50,32 +50,32 @@ type MockedEC2Svc struct {
 
 func (e *MockedEC2Svc) New() {
 	e.Subnets = []*ec2.Subnet{
-		&ec2.Subnet{
+		{
 			SubnetId: aws.String("subnet-12345"),
 			VpcId:    aws.String("vpc-12345"),
 			Tags: []*ec2.Tag{
-				&ec2.Tag{
+				{
 					Key:   aws.String("Name"),
 					Value: aws.String("Subnet 1"),
 				},
 			},
 		},
-		&ec2.Subnet{
+		{
 			SubnetId: aws.String("subnet-67890"),
 			VpcId:    aws.String("vpc-67890"),
 		},
 	}
 	e.Regions = []*ec2.Region{
-		&ec2.Region{
+		{
 			RegionName: aws.String("region-a"),
 		},
-		&ec2.Region{
+		{
 			RegionName: aws.String("region-b"),
 		},
 	}
 	e.AvailabilityZones = []*ec2.AvailabilityZone{
-		&ec2.AvailabilityZone{},
-		&ec2.AvailabilityZone{},
+		{},
+		{},
 	}
 }
 
@@ -305,7 +305,7 @@ func (e *MockedEC2Svc) AuthorizeSecurityGroupIngress(input *ec2.AuthorizeSecurit
 func (e *MockedEC2Svc) DescribeInstancesPages(input *ec2.DescribeInstancesInput, fn func(*ec2.DescribeInstancesOutput, bool) bool) error {
 	output := &ec2.DescribeInstancesOutput{
 		Reservations: []*ec2.Reservation{
-			&ec2.Reservation{
+			{
 				Instances: e.Instances,
 			},
 		},
@@ -325,7 +325,7 @@ func (e *MockedEC2Svc) CreateTags(input *ec2.CreateTagsInput) (*ec2.CreateTagsOu
 func (e *MockedEC2Svc) RunInstances(input *ec2.RunInstancesInput) (*ec2.Reservation, error) {
 	output := &ec2.Reservation{
 		Instances: []*ec2.Instance{
-			&ec2.Instance{
+			{
 				InstanceId: aws.String("i-12345"),
 			},
 		},


### PR DESCRIPTION
*Issue #, if available:*
none

*Description of changes:*
change 'ez' to 'simple' everywhere to align the code with the repository name. Done in preparation of adding this to the aws-homebrew tap. 

Depending on the context, the format could be slightly different now than before. Examples: 
```
'ez-ec2' -> 'simple-ec2'
'ezec2' -> 'simpleEc2'
'Ezec2' -> 'SimpleEc2'
'EZEC2' -> 'SIMPLE_EC2'
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
