### PR TITLE
remove explicit interactive mode on connect and terminate cmds

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -14,7 +14,6 @@
 package cmd
 
 import (
-	"fmt"
 	"strings"
 
 	"simple-ec2/pkg/cli"
@@ -42,21 +41,18 @@ func init() {
 		"The region in which the instance you want to connect locates")
 	connectCmd.Flags().StringVarP(&instanceIdConnectFlag, "instance-id", "n", "",
 		"The instance id of the instance you want to connect to")
-	connectCmd.Flags().BoolVarP(&isInteractive, "interactive", "i", false, "Interactive mode")
 }
 
 // The main function
 func connect(cmd *cobra.Command, args []string) {
-	if !ValidateConnectFlags() {
-		return
-	}
-
 	// Start a new session, with the default credentials and config loading
-	sess := session.Must(session.NewSessionWithOptions(session.Options{SharedConfigState: session.SharedConfigEnable}))
+	sess := session.Must(session.NewSessionWithOptions(
+		session.Options{SharedConfigState: session.SharedConfigEnable}))
+
 	ec2helper.GetDefaultRegion(sess)
 	h := ec2helper.New(sess)
 
-	if isInteractive {
+	if instanceIdConnectFlag == "" {
 		connectInteractive(h)
 	} else {
 		connectNonInteractive(h)
@@ -105,22 +101,6 @@ func connectNonInteractive(h *ec2helper.EC2Helper) {
 	if cli.ShowError(err, "Connecting to instance failed") {
 		return
 	}
-}
-
-// Validate flags using simple rules. Return true if the flags are validated, false otherwise
-func ValidateConnectFlags() bool {
-	if !isInteractive {
-		if instanceIdConnectFlag == "" && regionFlag == "" {
-			fmt.Println("Not in interactive mode and no flag is specified")
-			return false
-		}
-		if instanceIdConnectFlag == "" {
-			fmt.Println("Not in interactive mode and instance id is not specified")
-			return false
-		}
-	}
-
-	return true
 }
 
 // Get the information of the instance and connect to it

--- a/cmd/terminate.go
+++ b/cmd/terminate.go
@@ -41,21 +41,17 @@ func init() {
 		"The region in which the instances you want to terminate locates")
 	terminateCmd.Flags().StringSliceVarP(&instanceIdFlag, "instance-ids", "n", nil,
 		"The instance ids of the instances you want to terminate")
-	terminateCmd.Flags().BoolVarP(&isInteractive, "interactive", "i", false, "Interactive mode")
 }
 
 // The main function
 func terminate(cmd *cobra.Command, args []string) {
-	if !ValidateTerminateFlags() {
-		return
-	}
-
 	// Start a new session, with the default credentials and config loading
-	sess := session.Must(session.NewSessionWithOptions(session.Options{SharedConfigState: session.SharedConfigEnable}))
+	sess := session.Must(session.NewSessionWithOptions(
+		session.Options{SharedConfigState: session.SharedConfigEnable}))
 	ec2helper.GetDefaultRegion(sess)
 	h := ec2helper.New(sess)
 
-	if isInteractive {
+	if instanceIdFlag == nil {
 		terminateInteractive(h)
 	} else {
 		terminateNonInteractive(h)
@@ -113,19 +109,4 @@ func terminateNonInteractive(h *ec2helper.EC2Helper) {
 	}
 
 	cli.ShowError(h.TerminateInstances(instanceIdFlag), "Terminating instances failed")
-}
-
-// Validate flags using some simple rules. Return true if the flags are validated, false otherwise
-func ValidateTerminateFlags() bool {
-	if !isInteractive && instanceIdFlag == nil && regionFlag == "" {
-		fmt.Println("Not in interactive mode and no flag is specified")
-		return false
-	}
-
-	if !isInteractive && instanceIdFlag == nil {
-		fmt.Println("Not in interactive mode and instance ids are not specified")
-		return false
-	}
-
-	return true
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
 - Remove explicit interactive mode on `connect` and `terminate` commands and instead implicitly determine if interactive mode is engaged by looking if the primary flag is set. This should be safe since there are no "sane" defaults for connect and terminate. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
