### PR TITLE
remove sshpass as a dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,6 @@ before_install:
   - 'unzip awscli-bundle.zip'
   - './awscli-bundle/install -b ~/bin/aws'
   - 'export PATH=~/bin:$PATH'
-  - 'wget http://sourceforge.net/projects/sshpass/files/latest/download -O sshpass.tar.gz'
-  - 'tar -xvf sshpass.tar.gz'
-  - 'cd sshpass-1.06'
-  - './configure'
-  - 'sudo make install'
-  - 'cd ..'
 
 matrix:
   include:

--- a/README.md
+++ b/README.md
@@ -47,11 +47,8 @@ export AWS_SECRET_ACCESS_KEY="..."
 # Set default Region (optional)
 export AWS_REGION="us-east-1" 
 ```
-2. Install sshpass (1.06+)
 
-To install sshpass (1.06+), you can refer to this [guide](https://gist.github.com/arunoda/7790979). AWS Simple EC2 CLI requires sshpass version to be higher than 1.06. 
-
-3. Install AWS Simple EC2 CLI w/ Curl
+2. Install AWS Simple EC2 CLI w/ Curl
 #### MacOS/Linux
 ```
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
 -  Remove sshpass as a dependency. It doesn't provide any value other than in testing and is a significant hurdle for install. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
