### PR TITLE
Fix weird space in help

### DIFF
--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -30,8 +30,8 @@ import (
 var launchCmd = &cobra.Command{
 	Use:   "launch",
 	Short: "Launch an Amazon EC2 instance",
-	Long: `Launch an Amazon EC2 instance with the default configurations. 
-	All configurations can be overridden by configurations provided by configuration files or user input`,
+	Long: "Launch an Amazon EC2 instance with the default configurations. " +
+		"All configurations can be overridden by configurations provided by configuration files or user input.",
 	Run: launch,
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,8 +23,8 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "simple-ec2",
 	Short: "AWS Simple EC2 CLI (simple-ec2) is a simple tool to launch, connect and terminate Amazon EC2 instances",
-	Long: `AWS Simple EC2 CLI (simple-ec2) is a simple tool to launch, connect and terminate Amazon EC2 instances.
-	Users can easily launch an instance with or without custom configurations.`,
+	Long: "AWS Simple EC2 CLI (simple-ec2) is a simple tool to launch, connect and terminate Amazon EC2 instances. " +
+		"Users can easily launch an instance with or without custom configurations.",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("This command cannot be used alone. Please refer to simple-ec2 --help for available command combinations")
 	},


### PR DESCRIPTION
Remove weird space from the help prompt. Previously, the new line was followed with a tab space.

````
$ simple-ec2 help launch
                                                                                                                            
Launch an Amazon EC2 instance with the default configurations. All configurations can be overridden by configurations provided by configuration files or user input.
````


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
