### PR TITLE
Show help as default

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,9 +25,6 @@ var rootCmd = &cobra.Command{
 	Short: "AWS Simple EC2 CLI (simple-ec2) is a simple tool to launch, connect and terminate Amazon EC2 instances",
 	Long: "AWS Simple EC2 CLI (simple-ec2) is a simple tool to launch, connect and terminate Amazon EC2 instances. " +
 		"Users can easily launch an instance with or without custom configurations.",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("This command cannot be used alone. Please refer to simple-ec2 --help for available command combinations")
-	},
 }
 
 // Execute adds all child commands to the root command sets flags appropriately.


### PR DESCRIPTION
Show help as default. No need to add help flag.

```
$ ./build/simple-ec2
AWS Simple EC2 CLI (simple-ec2) is a simple tool to launch, connect and terminate Amazon EC2 instances. Users can easily launch an instance with or without custom configurations.

Usage:
  simple-ec2 [command]

Available Commands:
  connect     Connect to an Amazon EC2 Instance
  help        Help about any command
  launch      Launch an Amazon EC2 instance
  terminate   Terminate Amazon EC2 Instances
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
