### PR TITLE
Fix summary display

### DIFF
--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -900,7 +900,6 @@ func AskConfirmationWithInput(simpleConfig *config.SimpleInfo, detailedConfig *c
 
 	// If edit is allowed, give all items a number and fill the indexed options
 	if allowEdit {
-		counter := 1
 		for i := 0; i < len(data); i++ {
 			// Skip region
 			if data[i][0] == cli.ResourceRegion {
@@ -928,8 +927,7 @@ func AskConfirmationWithInput(simpleConfig *config.SimpleInfo, detailedConfig *c
 				} else {
 					indexedOptions = append(indexedOptions, data[i][0])
 				}
-				data[i][0] = fmt.Sprintf("%d.%s", counter, data[i][0])
-				counter++
+				data[i][0] = fmt.Sprintf("%s", data[i][0])
 			}
 		}
 	}


### PR DESCRIPTION
Fix summary display. We don't require numbering as this is a boolean (yes/no) confirmation. 

Sample display:

```
Please confirm if you would like to launch instance with following options:

+--------------------------------------+---------------------------------------------------+
| Region                               | us-west-2                                         |
+--------------------------------------+---------------------------------------------------+
| VPC                                  | XYZ VPC(vpc-0sa9cc174360671a1)                    |
+--------------------------------------+---------------------------------------------------+
| Subnet                               | ABCDE Headnode Subnet 1(subnet-0f32cc816072ca44a) |
+--------------------------------------+---------------------------------------------------+
| Instance Type                        | m5.xlarge                                         |
+--------------------------------------+---------------------------------------------------+
| Image                                | ami-07a0da1997b55babc                             |
+--------------------------------------+---------------------------------------------------+
| Security Group                       | sg-0537aaaf28ebd11bd                              |
+--------------------------------------+---------------------------------------------------+
| Keep EBS Volume(s) After Termination | false                                             |
+--------------------------------------+---------------------------------------------------+
| Auto Termination Timer in Minutes    | 1                                                 |
+--------------------------------------+---------------------------------------------------+
| EBS Volumes                          | /dev/xvda(gp2): 8 GiB                             |
+--------------------------------------+---------------------------------------------------+
[ yes / no ]
Your Choice >>
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
