### PR TITLE
Fix terminate

### DIFF
--- a/cmd/terminate.go
+++ b/cmd/terminate.go
@@ -83,18 +83,15 @@ func terminateInteractive(h *ec2helper.EC2Helper) {
 	for {
 		// Ask instance ID
 		instanceIdAnswer, err := question.AskInstanceIds(h, instanceIds)
-		cli.ShowError(err, "Asking instance ID failed")
+		if cli.ShowError(err, "Terminate Error") {
+			return
+		}
 
 		if instanceIdAnswer == nil || *instanceIdAnswer == cli.ResponseNo {
 			break
 		} else {
 			instanceIds = append(instanceIds, *instanceIdAnswer)
 		}
-	}
-
-	if len(instanceIds) <= 0 {
-		fmt.Println("No instance available to terminate in this region")
-		return
 	}
 
 	if question.AskTerminationConfirmation(instanceIds) == cli.ResponseYes {

--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -1033,7 +1033,7 @@ func AskInstanceIds(h *ec2helper.EC2Helper, addedInstanceIds []string) (*string,
 
 	// If no instance is available, simply don't ask
 	if len(data) <= 0 {
-		return nil, errors.New("No instance available to terminate")
+		return nil, errors.New("No instance available in selected region for termination")
 	}
 
 	// Add "done" option, if the added instance ids slice is not empty


### PR DESCRIPTION
Fix multiple error messages for instance not available to terminate. 

Sample message after this fix:
```
Select the region:
[Press enter to choose default: us-east-1]
+--------+----------------+---------------------------+
| OPTION |     REGION     |        DESCRIPTION        |
+--------+----------------+---------------------------+
| 1.     | ap-northeast-1 | Asia Pacific (Tokyo)      |
+--------+----------------+---------------------------+
| 2.     | ap-northeast-2 | Asia Pacific (Seoul)      |
+--------+----------------+---------------------------+
| 3.     | ap-northeast-3 | Asia Pacific (Osaka)      |
+--------+----------------+---------------------------+
| 4.     | ap-south-1     | Asia Pacific (Mumbai)     |
+--------+----------------+---------------------------+
| 5.     | ap-southeast-1 | Asia Pacific (Singapore)  |
+--------+----------------+---------------------------+
| 6.     | ap-southeast-2 | Asia Pacific (Sydney)     |
+--------+----------------+---------------------------+
| 7.     | ca-central-1   | Canada (Central)          |
+--------+----------------+---------------------------+
| 8.     | eu-central-1   | Europe (Frankfurt)        |
+--------+----------------+---------------------------+
| 9.     | eu-north-1     | Europe (Stockholm)        |
+--------+----------------+---------------------------+
| 10.    | eu-west-1      | Europe (Ireland)          |
+--------+----------------+---------------------------+
| 11.    | eu-west-2      | Europe (London)           |
+--------+----------------+---------------------------+
| 12.    | eu-west-3      | Europe (Paris)            |
+--------+----------------+---------------------------+
| 13.    | sa-east-1      | South America (Sao Paulo) |
+--------+----------------+---------------------------+
| 14.    | us-east-1      | US East (N. Virginia)     |
+--------+----------------+---------------------------+
| 15.    | us-east-2      | US East (Ohio)            |
+--------+----------------+---------------------------+
| 16.    | us-west-1      | US West (N. California)   |
+--------+----------------+---------------------------+
| 17.    | us-west-2      | US West (Oregon)          |
+--------+----------------+---------------------------+
Your Choice >> 10
Terminate Error: No instance available in selected region for termination
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
