### PR TITLE
Fix terminate bug when there exists just single instance

### DIFF
--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -1030,12 +1030,17 @@ func AskInstanceIds(h *ec2helper.EC2Helper, addedInstanceIds []string) (*string,
 	data, indexedOptions, finalCounter := table.AppendInstances(data, indexedOptions, instances,
 		addedInstanceIds)
 
-	// If no instance is available, simply don't ask
-	if len(data) <= 0 {
+	// There are no instances available for termination in selected region
+	if len(data) <= 0 && len(addedInstanceIds) == 0 {
 		return nil, errors.New("No instance available in selected region for termination")
 	}
+	
+	// Since no more instance(s) are available for termination, proceed with current selection
+	if len(data) == 0 && len(addedInstanceIds) > 0 {
+		return nil, nil
+	}
 
-	// Add "done" option, if the added instance ids slice is not empty
+	// Add "done" option, if instance(s) are already selected
 	if len(addedInstanceIds) > 0 {
 		indexedOptions = append(indexedOptions, cli.ResponseNo)
 		data = append(data, []string{fmt.Sprintf("%d.", finalCounter+1),


### PR DESCRIPTION
Found this bug during testing - when the region has just one instance and when the user selects it, it just fails with message ``No instance available for termination``. Apparently, there is an edge case which was not captured. It should be fixed with this PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
