### PR TITLE
Fix default based on region flag

### DIFF
--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -197,6 +197,11 @@ func launchInteractive(h *ec2helper.EC2Helper) {
 // Launch the instance non-interactively
 func launchNonInteractive(h *ec2helper.EC2Helper) {
 	simpleConfig := &config.SimpleInfo{}
+	if flagConfig.Region != "" {
+		simpleConfig.Region = flagConfig.Region
+	}
+
+	h.ChangeRegion(simpleConfig.Region)
 
 	// Try to get config from the config file
 	err := config.ReadConfig(simpleConfig, nil)
@@ -212,7 +217,6 @@ func launchNonInteractive(h *ec2helper.EC2Helper) {
 	// Override config with flags if applicable
 	config.OverrideConfigWithFlags(simpleConfig, &flagConfig)
 
-	h.ChangeRegion(simpleConfig.Region)
 
 	// When the flags specify a launch template
 	if flagConfig.LaunchTemplateId != "" {


### PR DESCRIPTION
There was a bug in launch non-interactive mode when the user specified only the region flag. The flow of events were:

1. Get defaults based on default region
2. Override it with the flags specified. If the region was overridden then the default were incorrect.

With this change:
1. Set region if specified
2. Get defaults for the specified region

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
