### PR TITLE
add additional tests and move from travis to github actions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+Issue #, if available:
+
+Description of changes:
+
+By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,62 @@
+name: Simple EC2 CLI CI and Release
+
+on: [push, pull_request, workflow_dispatch]
+
+env:
+  DEFAULT_GO_VERSION: ^1.15
+  IS_PUSH: ${{ github.event_name == 'push' }}
+  GITHUB_USERNAME: ${{ secrets.EC2_BOT_GITHUB_USERNAME }}
+  GITHUB_TOKEN: ${{ secrets.EC2_BOT_GITHUB_TOKEN }}
+
+jobs:
+
+  buildAndTest:
+    name: Build and Test
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.DEFAULT_GO_VERSION }}
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Unit Tests
+      run: make unit-test
+    
+    - name: Lints
+      run: make spellcheck shellcheck
+
+    - name: Go Report Card Tests
+      run: make go-report-card-test
+    
+    - name: Brew Sync Dry run
+      run: make homebrew-sync-dry-run
+
+    - name: License Test
+      if: ${{ env.IS_PUSH == true }}
+      run: make license-test
+
+    - name: Build Binaries
+      run: make build-binaries
+
+    - name: Build Docker Images
+      run: make build-docker-images
+
+  release:
+    name: Release
+    runs-on: ubuntu-20.04
+    needs: [buildAndTest]
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    steps:
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.DEFAULT_GO_VERSION }}
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+    
+    - name: Release Assets
+      run: make release

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ GOARCH ?= amd64
 GOPROXY ?= "https://proxy.golang.org,direct"
 SUPPORTED_PLATFORMS ?= "windows/amd64,darwin/amd64,linux/amd64,linux/arm64,linux/arm"
 SELECTOR_PKG_VERSION_VAR=github.com/awslabs/aws-simple-ec2-cli/v2/pkg/selector.versionID
-LATEST_RELEASE_TAG=$(shell git tag | tail -1)
-PREVIOUS_RELEASE_TAG=$(shell git tag | tail -2 | head -1)
+LATEST_RELEASE_TAG=$(shell git describe --tags --abbrev=0)
+PREVIOUS_RELEASE_TAG=$(shell git describe --abbrev=0 --tags `git rev-list --tags --skip=1  --max-count=1`)
 
 # The main CloudFormation template for creating a new stack during launch
 SIMPLE_EC2_CLOUDFORMATION_TEMPLATE_FILE=${MAKEFILE_PATH}/cloudformation_template.json

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -217,7 +217,6 @@ func launchNonInteractive(h *ec2helper.EC2Helper) {
 	// Override config with flags if applicable
 	config.OverrideConfigWithFlags(simpleConfig, &flagConfig)
 
-
 	// When the flags specify a launch template
 	if flagConfig.LaunchTemplateId != "" {
 		// If using a launch template, ignore the config file. Only read from the flags

--- a/pkg/ec2helper/ec2helper.go
+++ b/pkg/ec2helper/ec2helper.go
@@ -685,7 +685,6 @@ func (h *EC2Helper) GetSecurityGroupsByIds(ids []string) ([]*ec2.SecurityGroup, 
 	return securityGroups, err
 }
 
-
 /*
 Get the default Security Group, given a VPC ID.
 Empty result is allowed.

--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -727,11 +727,11 @@ func AskSecurityGroups(groups []*ec2.SecurityGroup, addedGroups []string) string
 	optionsText := table.BuildTable(data, []string{"Option", "Security Group", "Description"})
 
 	answer := AskQuestion(&AskQuestionInput{
-		QuestionString: 	question,
-		DefaultOptionRepr: 	defaultOptionRepr,
-		DefaultOption:     	defaultOptionValue,
-		OptionsString:  	&optionsText,
-		IndexedOptions:  	indexedOptions,
+		QuestionString:    question,
+		DefaultOptionRepr: defaultOptionRepr,
+		DefaultOption:     defaultOptionValue,
+		OptionsString:     &optionsText,
+		IndexedOptions:    indexedOptions,
 	})
 
 	return answer
@@ -1034,7 +1034,7 @@ func AskInstanceIds(h *ec2helper.EC2Helper, addedInstanceIds []string) (*string,
 	if len(data) <= 0 && len(addedInstanceIds) == 0 {
 		return nil, errors.New("No instance available in selected region for termination")
 	}
-	
+
 	// Since no more instance(s) are available for termination, proceed with current selection
 	if len(data) == 0 && len(addedInstanceIds) > 0 {
 		return nil, nil

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -33,7 +33,7 @@ func BuildTable(data [][]string, header []string) string {
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetAutoWrapText(false)
 	table.SetRowLine(true)
-	
+
 	// Fill the table with data
 	for _, v := range data {
 		table.Append(v)

--- a/scripts/sync-to-aws-homebrew-tap
+++ b/scripts/sync-to-aws-homebrew-tap
@@ -1,0 +1,237 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+BUILD_DIR="${SCRIPTPATH}/../build"
+BUILD_ID=$(uuidgen | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')
+
+TAP_REPO="aws/homebrew-tap"
+TAP_NAME=$(echo ${TAP_REPO} | cut -d'/' -f2)
+
+SYNC_DIR="${BUILD_DIR}/homebrew-sync"
+FORK_DIR="${SYNC_DIR}/${TAP_NAME}"
+DOWNLOAD_DIR="${BUILD_DIR}/downloads"
+BREW_CONFIG_DIR="${BUILD_DIR}/brew-config"
+
+REPO=$(make -s -f "${SCRIPTPATH}/../Makefile" repo-full-name)
+BINARY_BASE=""
+PLATFORMS=("darwin/amd64" "linux/amd64")
+DRY_RUN=0
+
+GH_CLI_VERSION="0.10.1"
+GH_CLI_CONFIG_PATH="${HOME}/.config/gh/config.yml"
+KERNEL=$(uname -s | tr '[:upper:]' '[:lower:]')
+OS="${KERNEL}"
+if [[ "${KERNEL}" == "darwin" ]]; then 
+  OS="macOS"
+fi
+
+VERSION_REGEX="^v[0-9]+\.[0-9]+\.[0-9]+\$"
+VERSION=$(make -s -f "${SCRIPTPATH}/../Makefile" version)
+
+USAGE=$(cat << EOM
+  Usage: sync-to-aws-homebrew-tap  -r <repo> -b <binary-basename> -p <platform_pairs>
+  Syncs tar.gz\'d binaries to the aws/homebrew-tap
+
+  Example: sync-to-aws-homebrew-tap -r "awslabs/aws-simple-ec2-cli"
+          Required:
+            -b          Binary basename (i.e. -b "simple-ec2")
+
+          Optional:
+            -r          Github repo to sync to in the form of "org/name"  (i.e. -r "awslabs/aws-simple-ec2-cli") [DEFAULT: output of \`make repo-full-name\`]
+            -v          VERSION: The application version of the docker image [DEFAULT: output of \`make version\`]
+            -p          Platform pair list (os/architecture) [DEFAULT: linux/amd64]
+            -d          Dry-Run will do all steps except pushing to git and opening the sync PR
+EOM
+)
+
+# Process our input arguments
+while getopts "p:b:r:v:d" opt; do
+  case ${opt} in
+    r ) # Github repo
+        REPO="$OPTARG"
+      ;;
+    b ) # binary basename
+        BINARY_BASE="$OPTARG"
+      ;;
+    p ) # Supported Platforms
+        IFS=',' read -ra PLATFORMS <<< "$OPTARG"
+      ;;
+    v ) # App Version
+        VERSION="$OPTARG"
+      ;;
+    d ) # Dry Run
+        DRY_RUN=1
+      ;;
+    \? )
+        echo "$USAGE" 1>&2
+        exit
+      ;;
+  esac
+done
+
+if [[ -z "${BINARY_BASE}" ]]; then 
+  echo "Binary Basename (-b) must be specified"
+  exit 3
+fi
+
+if [[ ! "${VERSION}" =~ $VERSION_REGEX ]]; then
+  echo "🙈 Not on a current release, so not syncing with tap $TAP_REPO"
+  exit 3
+fi
+
+if [[ -z "${REPO}" ]]; then 
+  echo "Repo (-r) must be specified if no \"make repo-full-name\" target exists"
+fi
+
+if [[ -z $(command -v gh) ]] || [[ ! $(gh --version) =~ $GH_CLI_VERSION ]]; then
+  mkdir -p ${BUILD_DIR}/gh
+  curl -Lo ${BUILD_DIR}/gh/gh.tar.gz "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_${OS}_amd64.tar.gz"
+  tar -C ${BUILD_DIR}/gh -xvf "${BUILD_DIR}/gh/gh.tar.gz"
+  export PATH="${BUILD_DIR}/gh/gh_${GH_CLI_VERSION}_${OS}_amd64/bin:$PATH"
+  if [[ ! $(gh --version) =~ $GH_CLI_VERSION ]]; then
+    echo "❌ Failed install of github cli"
+    exit 4
+  fi
+fi
+
+function restore_gh_config() {
+  mv -f "${GH_CLI_CONFIG_PATH}.bkup" "${GH_CLI_CONFIG_PATH}" || :
+}
+
+if [[ -n $(env | grep GITHUB_TOKEN) ]] && [[ -n "${GITHUB_TOKEN}" ]]; then
+  trap restore_gh_config EXIT INT TERM ERR
+  mkdir -p "${HOME}/.config/gh"
+  cp -f "${GH_CLI_CONFIG_PATH}" "${GH_CLI_CONFIG_PATH}.bkup" || :
+  cat << EOF > "${GH_CLI_CONFIG_PATH}"
+hosts:
+    github.com:
+        oauth_token: ${GITHUB_TOKEN}
+        user: ${GITHUB_USERNAME}
+EOF
+fi
+
+VERSION_NUM=$(echo "${VERSION}" | cut -c 2- | tr -d '\n')
+
+function fail() {
+  echo "❌ Homebrew sync failed"
+  exit 5
+}
+
+trap fail ERR TERM INT
+
+rm -rf "${DOWNLOAD_DIR}" "${SYNC_DIR}" "${BREW_CONFIG_DIR}"
+mkdir -p "${DOWNLOAD_DIR}" "${SYNC_DIR}" "${BREW_CONFIG_DIR}"
+
+BASE_ASSET_URL="https://github.com/${REPO}/releases/download/${VERSION}/${BINARY_BASE}"
+MAC_HASH=""
+LINUX_HASH=""
+LINUX_ARM64_HASH=""
+
+function hash_file() {
+  local file="${1}"
+  echo "$(openssl dgst -sha256 "${file}" | cut -d' ' -f2 | tr -d '\n')"
+}
+
+for os_arch in "${PLATFORMS[@]}"; do
+    os=$(echo "${os_arch}" | cut -d'/' -f1)
+    arch=$(echo "${os_arch}" | cut -d'/' -f2)
+
+    ## Windows is not supported with homebrew
+    if [[ "${os}" == "windows" ]]; then 
+      continue
+    fi
+
+    asset_url="${BASE_ASSET_URL}-${os}-${arch}.tar.gz"
+    asset_file="${BINARY_BASE}-${os}-${arch}.tar.gz"
+    asset_file_path="${DOWNLOAD_DIR}/${asset_file}"
+
+    curl -H 'Cache-Control: no-cache' -Lo "${asset_file_path}" "${asset_url}?$(date +%s)"
+
+    asset_file_size=$(du -k "${asset_file_path}" | cut -f1)
+    if [[ "${asset_file_size}" -lt 100 ]]; then
+      ## If we cannot download and dry-run is set, build it locally
+      if [[ "${DRY_RUN}" -eq 1 ]]; then 
+        ${SCRIPTPATH}/build-binaries -d -v "${VERSION}" -p "${os_arch}"
+        cp "${BUILD_DIR}/bin/${asset_file}" ${asset_file_path}
+      else 
+        echo "❗️${asset_file_path} is empty, skipping"
+        continue
+      fi
+    fi
+
+    if [[ "${os}" == "darwin" ]]; then
+      MAC_HASH=$(hash_file "${asset_file_path}")
+    elif [[ "${os}" == "linux" && "${arch}" == "amd64" ]]; then
+      LINUX_HASH=$(hash_file "${asset_file_path}")
+    elif [[ "${os}" == "linux" && "${arch}" == "arm64" ]]; then
+      LINUX_ARM64_HASH=$(hash_file "${asset_file_path}")
+    fi
+
+done
+
+cat << EOM > "${BREW_CONFIG_DIR}/${BINARY_BASE}.json"
+{
+    "name": "${BINARY_BASE}",
+    "version": "${VERSION_NUM}",
+    "bin": "${BINARY_BASE}",
+    "bottle": {
+        "root_url": "${BASE_ASSET_URL}",
+        "sha256": {
+            "sierra": "${MAC_HASH}",
+            "linux": "${LINUX_HASH}",
+            "linux_arm": "${LINUX_ARM64_HASH}"
+        }
+    }
+}
+EOM
+
+if [[ "${DRY_RUN}" -eq 0 ]]; then 
+  if [[ -z "${MAC_HASH}" ]] && [[ -z "${LINUX_HASH}" ]] && [[ -z "${LINUX_ARM64_HASH}" ]]; then 
+    echo "❌ No hashes were calculated and dry-run is NOT engaged. Bailing out so we don't open a bad PR to the tap."
+    exit 4
+  fi
+  cd "${SYNC_DIR}"
+  gh repo fork $TAP_REPO --clone --remote
+  cd "${FORK_DIR}"
+  git remote set-url origin https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/${GITHUB_USERNAME}/${TAP_NAME}.git
+  DEFAULT_BRANCH=$(git rev-parse --abbrev-ref HEAD | tr -d '\n')
+
+  git config user.name "ec2-bot 🤖"
+  git config user.email "ec2-bot@users.noreply.github.com"
+  
+  # Sync the fork
+  git pull upstream "${DEFAULT_BRANCH}"
+  git push -u origin "${DEFAULT_BRANCH}"
+
+  FORK_RELEASE_BRANCH="${BINARY_BASE}-${VERSION}-${BUILD_ID}"
+  git checkout -b "${FORK_RELEASE_BRANCH}" upstream/${DEFAULT_BRANCH}
+
+  cp "${BREW_CONFIG_DIR}/${BINARY_BASE}.json" "${FORK_DIR}/bottle-configs/${BINARY_BASE}.json"
+  
+  git add "bottle-configs/${BINARY_BASE}.json"
+  git commit -m "${BINARY_BASE} update to version ${VERSION_NUM}"
+
+  RELEASE_ID=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+    https://api.github.com/repos/${REPO}/releases | \
+    jq --arg VERSION "$VERSION" '.[] | select(.tag_name==$VERSION) | .id')
+  
+  RELEASE_NOTES=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
+    https://api.github.com/repos/${REPO}/releases/${RELEASE_ID} | \
+    jq -r '.body')
+
+  PR_BODY=$(cat << EOM
+  ## ${BINARY_BASE} ${VERSION} Automated Release! 🤖🤖
+
+  ### Release Notes 📝:
+
+  ${RELEASE_NOTES}
+EOM
+)
+
+  git push -u origin "${FORK_RELEASE_BRANCH}"
+  gh pr create --title "🥳 ${BINARY_BASE} ${VERSION} Automated Release! 🥑" \
+    --body "${PR_BODY}"
+fi
+
+echo "✅ Homebrew sync complete"

--- a/scripts/upload-resources-to-github
+++ b/scripts/upload-resources-to-github
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+VERSION=$(make -s -f $SCRIPTPATH/../Makefile version)
+
+RELEASE_ID=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+    https://api.github.com/repos/awslabs/aws-simple-ec2-cli/releases | \
+    jq --arg VERSION "$VERSION" '.[] | select(.tag_name==$VERSION) | .id')
+
+for binary in $SCRIPTPATH/../build/bin/*; do 
+    curl \
+        -H "Authorization: token $GITHUB_TOKEN" \
+        -H "Content-Type: $(file -b --mime-type $binary)" \
+        --data-binary @$binary \
+        "https://uploads.github.com/repos/awslabs/aws-simple-ec2-cli/releases/$RELEASE_ID/assets?name=$(basename $binary)"
+done
+

--- a/test/go-report-card-test/Dockerfile
+++ b/test/go-report-card-test/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1
+
+WORKDIR /app
+
+RUN go get github.com/gojp/goreportcard
+RUN cd $GOPATH/src/github.com/gojp/goreportcard && (make install || cd / && curl -L https://git.io/vp6lP | sh)
+
+RUN go get github.com/gojp/goreportcard/cmd/goreportcard-cli
+
+RUN go get -u golang.org/x/tools/cmd/goimports
+
+CMD $GOPATH/bin/goreportcard-cli -v -t 90

--- a/test/go-report-card-test/run-report-card-test.sh
+++ b/test/go-report-card-test/run-report-card-test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+THRESHOLD=90
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+EXIT_CODE=0
+
+function fail() {
+    echo "❌ Test failed to meet go-report-card threshold score of: $THRESHOLD"
+    exit 1
+}
+trap fail ERR
+
+docker build --build-arg=GOPROXY=direct -t go-report-card-cli $SCRIPTPATH
+if [[ $(docker run -it -v $SCRIPTPATH/../../:/app go-report-card-cli /go/bin/goimports -l /app/) ]]; then
+    echo "❌ goimports found a problem in go source files. See above for the files with problems."
+    EXIT_CODE=2
+else
+    echo "✅ goimports found no formatting errors in go source files"
+fi
+
+
+docker run -t -v $SCRIPTPATH/../../:/app go-report-card-cli /go/bin/goreportcard-cli -v -t $THRESHOLD
+
+exit $EXIT_CODE

--- a/test/license-test/Dockerfile
+++ b/test/license-test/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1
+
+WORKDIR /app
+
+COPY license-config.hcl .
+ARG GOPROXY="https://proxy.golang.org,direct"
+RUN GO111MODULE=on go get github.com/mitchellh/golicense
+
+CMD $GOPATH/bin/golicense 

--- a/test/license-test/gen-license-report.sh
+++ b/test/license-test/gen-license-report.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+BUILD_DIR="$SCRIPTPATH/../../build"
+mkdir -p $BUILD_DIR
+export PATH="$PATH:$(go env GOPATH | sed 's+:+/bin+g')/bin"
+
+go get github.com/mitchellh/golicense
+make -s -f $SCRIPTPATH/../../Makefile compile 
+golicense -out-xlsx=$BUILD_DIR/report.xlsx $SCRIPTPATH/license-config.hcl $BUILD_DIR/aws-simple-ec2-cli
+

--- a/test/license-test/license-config.hcl
+++ b/test/license-test/license-config.hcl
@@ -1,0 +1,19 @@
+allow = [
+   "MIT", 
+   "Apache-2.0",
+   "BSD-3-Clause",
+   "ISC",
+   "MPL-2.0"
+]
+deny = [
+   "GNU General Public License v2.0"
+]
+translate = {
+
+}
+override = {
+  "sigs.k8s.io/yaml" = "MIT",
+  "github.com/gogo/protobuf" = "BSD-3-Clause"
+  "github.com/ghodss/yaml" = "MIT"
+  "github.com/aws/amazon-ec2-instance-selector" = "Apache-2.0"
+}

--- a/test/license-test/run-license-test.sh
+++ b/test/license-test/run-license-test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+BUILD_BIN="$SCRIPTPATH/../../build/bin"
+
+OS=$(uname | tr '[:upper:]' '[:lower:]')
+ARCH=amd64
+BIN_NAME=$(make -f $SCRIPTPATH/../../Makefile bin-name)
+BINARY_NAME="${BIN_NAME}-$OS-$ARCH"
+LICENSE_TEST_TAG="aeis-license-test"
+
+SUPPORTED_PLATFORMS="$OS/$ARCH" make -f $SCRIPTPATH/../../Makefile build-binaries
+
+SUPPORTED_PLATFORMS="$OS/$ARCH" make -s -f $SCRIPTPATH/../../Makefile build-binaries
+docker build --build-arg=GOPROXY=direct -t $LICENSE_TEST_TAG $SCRIPTPATH/
+docker run -it -e GITHUB_TOKEN --rm -v $SCRIPTPATH/:/test -v $BUILD_BIN/:/aeis-bin $LICENSE_TEST_TAG golicense /test/license-config.hcl /aeis-bin/$BINARY_NAME

--- a/test/readme-test/readme-codeblocks.go
+++ b/test/readme-test/readme-codeblocks.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+)
+
+// CodeBlock models the rundoc codeblock output
+type CodeBlock struct {
+	Code        string   `json:"code"`
+	Interpreter string   `json:"interpreter"`
+	Runs        []string `json:"Runs"`
+	Tags        []string `json:"tags"`
+}
+
+// RunDoc is the outer model for rundocs output
+type RunDoc struct {
+	CodeBlocks []CodeBlock `json:"code_blocks"`
+}
+
+// main takes a rundoc style report parsed from a README file and compares against actual file contents from the tag.
+// This is useful to ensure that code examples in the readme are up-to-date with actual example go source files
+// If they are in-sync, the source files are executed to make sure the functionality also works.
+func main() {
+	currentDir := flag.String("current-dir", "", "The current dir this script is called from")
+	flag.Parse()
+	scanner := bufio.NewScanner(os.Stdin)
+	var cb strings.Builder
+	cb.Grow(32)
+	for scanner.Scan() {
+		fmt.Fprintf(&cb, "%s", scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		log.Println(err)
+	}
+	codeBlocksJSON := cb.String()
+	runDoc := RunDoc{}
+	if err := json.Unmarshal([]byte(codeBlocksJSON), &runDoc); err != nil {
+		log.Fatal(err)
+	}
+	for _, codeBlock := range runDoc.CodeBlocks {
+		code := codeBlock.Code
+		tags := removeFromSlice(codeBlock.Tags, []string{codeBlock.Interpreter})
+		codeFileDir := fmt.Sprintf("%s/../../%s", *currentDir, tags[0])
+
+		switch codeBlock.Interpreter {
+		case "go":
+			if !compareBlockWithFile(code, codeFileDir) {
+				log.Fatalf("Code Block found in README.md does not match corresponding source file: %s", codeFileDir)
+			}
+		}
+	}
+}
+
+func compareBlockWithFile(codeBlock string, codePath string) bool {
+	fileContents, err := ioutil.ReadFile(codePath)
+	if err != nil {
+		log.Fatalf("Unable to read file contents at %s", codePath)
+	}
+	fileContentStr := removeWhitespace(string(fileContents))
+	codeBlock = removeWhitespace(string(codeBlock))
+	return fileContentStr == codeBlock
+}
+
+func removeFromSlice(original []string, removals []string) []string {
+	newSlice := []string{}
+	for i, element := range original {
+		for _, removal := range removals {
+			if removal == element {
+				newSlice = append(original[:i], original[i+1:]...)
+			}
+		}
+	}
+	return newSlice
+}
+
+func removeWhitespace(original string) string {
+	removed := strings.ReplaceAll(original, " ", "")
+	removed = strings.ReplaceAll(removed, "\t", "")
+	return strings.ReplaceAll(removed, "\n", "")
+}

--- a/test/readme-test/run-readme-codeblocks
+++ b/test/readme-test/run-readme-codeblocks
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo errexit
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+BUILD_DIR="$SCRIPTPATH/../../build"
+OS=$(uname | tr '[:upper:]' '[:lower:]')
+
+function exit_and_fail() {
+   echo "❌ Test Failed! README is not consistent with code examples."
+   exit 1
+}
+trap exit_and_fail INT ERR
+docker build --target=builder --build-arg="GOPROXY=direct" -t codeblocks -f $SCRIPTPATH/../../Dockerfile $SCRIPTPATH/../../
+docker build -t rundoc -f $SCRIPTPATH/rundoc-Dockerfile $SCRIPTPATH/
+function rd() {
+   docker run -it --rm -v $SCRIPTPATH/../../:/aeis rundoc rundoc "$@"
+}
+
+rundoc_output=$(rd list-blocks /aeis/README.md)
+example_files=($(echo $rundoc_output | jq -r '.code_blocks[] | .tags[1]'))
+interpreters=($(echo $rundoc_output | jq -r '.code_blocks[] | .interpreter'))
+
+## Execute --help check which compares the help codeblock in the README to the actual output of the binary
+rd list-blocks -T "bash#help" /aeis/README.md | jq -r '.code_blocks[0] .code' > $BUILD_DIR/readme_help.out
+docker run -t --rm codeblocks build/ec2-instance-selector --help > $BUILD_DIR/actual_help.out
+diff --ignore-all-space --ignore-blank-lines "$BUILD_DIR/actual_help.out" "$BUILD_DIR/readme_help.out"
+echo "✅ README help section matches actual binary output!"
+
+## Execute go codeblocks example tests which checks the go codeblocks in the readme with a source file path
+echo $rundoc_output | docker run -i --rm codeblocks go run test/readme-test/readme-codeblocks.go --current-dir /amazon-ec2-instance-selector/test/readme-test/
+echo "✅ Codeblocks match source files"
+
+for i in "${!example_files[@]}"; do
+   if [[ "${interpreters[$i]}" == "go" ]]; then
+      example_file="${example_files[$i]}"
+      example_bin=$(echo $example_file | cut -d'.' -f1)
+      mkdir -p $BUILD_DIR/examples
+      docker run -it -e GOOS=$OS -e GOARCH=amd64 -v $BUILD_DIR:/amazon-ec2-instance-selector/build --rm codeblocks go build -o build/examples/$example_bin $example_file
+      $BUILD_DIR/examples/$example_bin
+      echo "✅ $example_file Executed Successfully!"
+   fi
+done

--- a/test/readme-test/run-readme-codeblocks
+++ b/test/readme-test/run-readme-codeblocks
@@ -22,12 +22,12 @@ interpreters=($(echo $rundoc_output | jq -r '.code_blocks[] | .interpreter'))
 
 ## Execute --help check which compares the help codeblock in the README to the actual output of the binary
 rd list-blocks -T "bash#help" /aeis/README.md | jq -r '.code_blocks[0] .code' > $BUILD_DIR/readme_help.out
-docker run -t --rm codeblocks build/ec2-instance-selector --help > $BUILD_DIR/actual_help.out
+docker run -t --rm codeblocks build/simple-ec2 --help > $BUILD_DIR/actual_help.out
 diff --ignore-all-space --ignore-blank-lines "$BUILD_DIR/actual_help.out" "$BUILD_DIR/readme_help.out"
 echo "✅ README help section matches actual binary output!"
 
 ## Execute go codeblocks example tests which checks the go codeblocks in the readme with a source file path
-echo $rundoc_output | docker run -i --rm codeblocks go run test/readme-test/readme-codeblocks.go --current-dir /amazon-ec2-instance-selector/test/readme-test/
+echo $rundoc_output | docker run -i --rm codeblocks go run test/readme-test/readme-codeblocks.go --current-dir /simple-ec2/test/readme-test/
 echo "✅ Codeblocks match source files"
 
 for i in "${!example_files[@]}"; do
@@ -35,7 +35,7 @@ for i in "${!example_files[@]}"; do
       example_file="${example_files[$i]}"
       example_bin=$(echo $example_file | cut -d'.' -f1)
       mkdir -p $BUILD_DIR/examples
-      docker run -it -e GOOS=$OS -e GOARCH=amd64 -v $BUILD_DIR:/amazon-ec2-instance-selector/build --rm codeblocks go build -o build/examples/$example_bin $example_file
+      docker run -it -e GOOS=$OS -e GOARCH=amd64 -v $BUILD_DIR:/simple-ec2/build --rm codeblocks go build -o build/examples/$example_bin $example_file
       $BUILD_DIR/examples/$example_bin
       echo "✅ $example_file Executed Successfully!"
    fi

--- a/test/readme-test/run-readme-spellcheck
+++ b/test/readme-test/run-readme-spellcheck
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+function exit_and_fail() {
+   echo "❌ Test Failed! Found a markdown file with spelling errors."
+   exit 1
+}
+trap exit_and_fail INT ERR TERM
+
+docker build -t misspell -f $SCRIPTPATH/spellcheck-Dockerfile $SCRIPTPATH/
+docker run -i --rm -v $SCRIPTPATH/../../:/aeis misspell /bin/bash -c 'find /aeis/ -type f -name "*.md" -not -path "build" | grep -v "/build/" | xargs misspell -error -debug'
+echo "✅ Markdown file spell check passed!"

--- a/test/readme-test/rundoc-Dockerfile
+++ b/test/readme-test/rundoc-Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3
+
+
+RUN pip3 install rundoc
+
+RUN touch /bin/go && chmod +x /bin/go
+
+CMD [ "rundoc" "--help" ]

--- a/test/readme-test/spellcheck-Dockerfile
+++ b/test/readme-test/spellcheck-Dockerfile
@@ -1,0 +1,5 @@
+FROM golang:1
+
+RUN go get -u github.com/client9/misspell/cmd/misspell
+
+CMD [ "/go/bin/misspell" ]

--- a/test/shellcheck/run-shellcheck
+++ b/test/shellcheck/run-shellcheck
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+BUILD_DIR="${SCRIPTPATH}/../../build"
+
+KERNEL=$(uname -s | tr '[:upper:]' '[:lower:]')
+SHELLCHECK_VERSION="0.7.1"
+
+function exit_and_fail() {
+   echo "❌ Test Failed! Found a shell script with errors."
+   exit 1
+}
+trap exit_and_fail INT ERR TERM
+
+curl -Lo ${BUILD_DIR}/shellcheck.tar.xz https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.${KERNEL}.x86_64.tar.xz
+tar -C ${BUILD_DIR} -xvf "${BUILD_DIR}/shellcheck.tar.xz"
+export PATH="${BUILD_DIR}/shellcheck-v${SHELLCHECK_VERSION}:$PATH"
+
+shellcheck -S error $(grep -Rn -e '#!.*/bin/bash' -e '#!.*/usr/bin/env bash' ${SCRIPTPATH}/../../ | grep ":[1-5]:" | cut -d':' -f1)
+
+echo "✅ All shell scripts look good! 😎"

--- a/test/testhelper/ec2helper_mock.go
+++ b/test/testhelper/ec2helper_mock.go
@@ -127,7 +127,7 @@ func (e *MockedEC2Svc) DescribeLaunchTemplateVersionsPages(input *ec2.DescribeLa
 	versions := []*ec2.LaunchTemplateVersion{}
 
 	if input.Versions != nil {
-		// Find all templates with specified version ID and tempalte ID
+		// Find all templates with specified version ID and template ID
 		for _, versionId := range input.Versions {
 			for _, version := range e.LaunchTemplateVersions {
 				if strconv.FormatInt(*version.VersionNumber, 10) == *versionId && *version.LaunchTemplateId == templateId {
@@ -136,7 +136,7 @@ func (e *MockedEC2Svc) DescribeLaunchTemplateVersionsPages(input *ec2.DescribeLa
 			}
 		}
 	} else {
-		// Find all templates with specified tempalte ID
+		// Find all templates with specified template ID
 		for _, version := range e.LaunchTemplateVersions {
 			if *version.LaunchTemplateId == templateId {
 				versions = append(versions, version)

--- a/test/testhelper/testhelper.go
+++ b/test/testhelper/testhelper.go
@@ -37,7 +37,7 @@ func StringSliceEqual(a, b []string) bool {
 
 	compareMap := map[string]int{}
 
-	// Add occurence to the map
+	// Add occurrence to the map
 	for _, element := range a {
 		// If element not present in the map, initialize counter
 		_, found := compareMap[element]
@@ -45,11 +45,11 @@ func StringSliceEqual(a, b []string) bool {
 			compareMap[element] = 0
 		}
 
-		// Add 1 occurence
+		// Add 1 occurrence
 		compareMap[element]++
 	}
 
-	// Subtract occurence from the map
+	// Subtract occurrence from the map
 	for _, element := range b {
 		// If element not present in the map, return false
 		_, found := compareMap[element]
@@ -57,7 +57,7 @@ func StringSliceEqual(a, b []string) bool {
 			return false
 		}
 
-		// Minus 1 occurence
+		// Minus 1 occurrence
 		compareMap[element]--
 	}
 


### PR DESCRIPTION
*Description of changes:*

 - Move from Travis CI to Github Actions
 - Add some baseline tests
       - shellcheck
       - spellcheck
       - go-report-card-test (ran `make fmt` and fixed some spelling errors to get the report card in the 90% range) 
       - license-test
       - brew-sync-dry-run ( we can run the dryrun until we start syncing to the aws tap)
       - added a release make target and the corresponding github upload script

Test run: https://github.com/bwagner5/simple-ec2-test/runs/1455849675?check_suite_focus=true

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
