### PR TITLE
add tags and boot script

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -26,4 +26,4 @@ var (
 	instanceIdFlag        []string
 )
 
-var flagConfig = config.SimpleInfo{}
+var flagConfig = config.NewSimpleInfo()

--- a/pkg/cfn/cfn.go
+++ b/pkg/cfn/cfn.go
@@ -217,7 +217,7 @@ func (c Cfn) DeleteStack(stackName string) error {
 func getSimpleEc2Tags() []*cloudformation.Tag {
 	simpleEc2Tags := []*cloudformation.Tag{}
 
-	tags := tag.GetTags()
+	tags := tag.GetSimpleEc2Tags()
 	for key, value := range *tags {
 		simpleEc2Tags = append(simpleEc2Tags, &cloudformation.Tag{
 			Key:   aws.String(key),

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -38,6 +38,8 @@ const (
 	ResourceSecurityGroup            = "Security Group"
 	ResourceSecurityGroupPlaceholder = "Security Group Placeholder"
 	ResourceIamInstanceProfile       = "IAM Instance Profile"
+	ResourceUserDataFilePath         = "Boot Script Filepath"
+	ResourceUserTags                 = "Tag Specification"
 )
 
 // Show errors if there are any. Return true when there are errors, and false when there is none
@@ -46,6 +48,5 @@ func ShowError(err error, message string) bool {
 		fmt.Println(message+":", err)
 		return true
 	}
-
 	return false
 }

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -38,8 +38,8 @@ const (
 	ResourceSecurityGroup            = "Security Group"
 	ResourceSecurityGroupPlaceholder = "Security Group Placeholder"
 	ResourceIamInstanceProfile       = "IAM Instance Profile"
-	ResourceUserDataFilePath         = "Boot Script Filepath"
-	ResourceUserTags                 = "Tag Specification"
+	ResourceBootScriptFilePath       = "Boot Script Filepath"
+	ResourceUserTags                 = "Tag Specification(key|value)"
 )
 
 // Show errors if there are any. Return true when there are errors, and false when there is none

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,8 +45,8 @@ type SimpleInfo struct {
 	AutoTerminationTimerMinutes   int
 	KeepEbsVolumeAfterTermination bool
 	IamInstanceProfile            string
-	UserDataFilePath              string
-	UserTags                      []string
+	BootScriptFilePath            string
+	UserTags                      map[string]string
 }
 
 /*
@@ -60,6 +60,12 @@ type DetailedInfo struct {
 	InstanceTypeInfo *ec2.InstanceTypeInfo
 	SecurityGroups   []*ec2.SecurityGroup
 	TagSpecs         []*ec2.TagSpecification
+}
+
+func NewSimpleInfo() *SimpleInfo {
+	var s SimpleInfo
+	s.UserTags = make(map[string]string)
+	return &s
 }
 
 // Get the home directory
@@ -128,8 +134,8 @@ func OverrideConfigWithFlags(simpleConfig *SimpleInfo, flagConfig *SimpleInfo) {
 	if flagConfig.IamInstanceProfile != "" {
 		simpleConfig.IamInstanceProfile = flagConfig.IamInstanceProfile
 	}
-	if flagConfig.UserDataFilePath != "" {
-		simpleConfig.UserDataFilePath = flagConfig.UserDataFilePath
+	if flagConfig.BootScriptFilePath != "" {
+		simpleConfig.BootScriptFilePath = flagConfig.BootScriptFilePath
 	}
 	if flagConfig.UserTags != nil {
 		simpleConfig.UserTags = flagConfig.UserTags

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,6 +45,8 @@ type SimpleInfo struct {
 	AutoTerminationTimerMinutes   int
 	KeepEbsVolumeAfterTermination bool
 	IamInstanceProfile            string
+	UserDataFilePath              string
+	UserTags                      []string
 }
 
 /*
@@ -57,6 +59,7 @@ type DetailedInfo struct {
 	Subnet           *ec2.Subnet
 	InstanceTypeInfo *ec2.InstanceTypeInfo
 	SecurityGroups   []*ec2.SecurityGroup
+	TagSpecs         []*ec2.TagSpecification
 }
 
 // Get the home directory
@@ -124,6 +127,12 @@ func OverrideConfigWithFlags(simpleConfig *SimpleInfo, flagConfig *SimpleInfo) {
 	}
 	if flagConfig.IamInstanceProfile != "" {
 		simpleConfig.IamInstanceProfile = flagConfig.IamInstanceProfile
+	}
+	if flagConfig.UserDataFilePath != "" {
+		simpleConfig.UserDataFilePath = flagConfig.UserDataFilePath
+	}
+	if flagConfig.UserTags != nil {
+		simpleConfig.UserTags = flagConfig.UserTags
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -67,13 +67,12 @@ const testLaunchTemplateId = "lt-12345"
 const testLaunchTemplateVersion = "1"
 const testNewVPC = true
 const testIamProfile = "iam-profile"
+const testUserDataFilePath = "some/path/to/userdata"
 
-const expectedJson = `{"Region":"us-somewhere","ImageId":"ami-12345","InstanceType":"t2.micro","SubnetId":"s-12345","LaunchTemplateId":"lt-12345","LaunchTemplateVersion":"1","SecurityGroupIds":["sg-12345","sg-67890"],"NewVPC":true,"AutoTerminationTimerMinutes":0,"KeepEbsVolumeAfterTermination":false,"IamInstanceProfile":"iam-profile"}`
+var testTags = []string{"testedBy:BRYAN", "brokenBy:CBASKIN"}
+var testSecurityGroup = []string{"sg-12345", "sg-67890"}
 
-var testSecurityGroup = []string{
-	"sg-12345",
-	"sg-67890",
-}
+const expectedJson = `{"Region":"us-somewhere","ImageId":"ami-12345","InstanceType":"t2.micro","SubnetId":"s-12345","LaunchTemplateId":"lt-12345","LaunchTemplateVersion":"1","SecurityGroupIds":["sg-12345","sg-67890"],"NewVPC":true,"AutoTerminationTimerMinutes":0,"KeepEbsVolumeAfterTermination":false,"IamInstanceProfile":"iam-profile","UserDataFilePath":"some/path/to/userdata","UserTags":["testedBy:BRYAN","brokenBy:CBASKIN"]}`
 
 func TestSaveConfig(t *testing.T) {
 	testConfig := &config.SimpleInfo{
@@ -86,6 +85,8 @@ func TestSaveConfig(t *testing.T) {
 		SecurityGroupIds:      testSecurityGroup,
 		NewVPC:                testNewVPC,
 		IamInstanceProfile:    testIamProfile,
+		UserDataFilePath:      testUserDataFilePath,
+		UserTags:              testTags,
 	}
 
 	err := config.SaveConfig(testConfig, aws.String(testConfigFileName))
@@ -103,6 +104,7 @@ func TestSaveConfig(t *testing.T) {
 	if expectedJson != string(readData) {
 		t.Errorf("Config file content incorrect, expect: \"%s\" got: \"%s\"",
 			expectedJson, string(readData))
+
 	}
 
 	os.Remove(testConfigFilePath)
@@ -120,6 +122,8 @@ func TestOverrideConfigWithFlags(t *testing.T) {
 		SecurityGroupIds:      testSecurityGroup,
 		NewVPC:                testNewVPC,
 		IamInstanceProfile:    testIamProfile,
+		UserDataFilePath:      testUserDataFilePath,
+		UserTags:              testTags,
 	}
 
 	config.OverrideConfigWithFlags(simpleConfig, flagConfig)
@@ -173,6 +177,14 @@ func compareConfig(correctConfig, otherConfig *config.SimpleInfo, t *testing.T) 
 		t.Errorf("IamInstanceProfile is not correct, expect: %s got %s",
 			correctConfig.IamInstanceProfile, otherConfig.IamInstanceProfile)
 	}
+	if correctConfig.UserDataFilePath != otherConfig.UserDataFilePath {
+		t.Errorf("UserDataFilePath is not correct, expect: %s got %s",
+			correctConfig.UserDataFilePath, otherConfig.UserDataFilePath)
+	}
+	if !th.StringSliceEqual(correctConfig.UserTags, otherConfig.UserTags) {
+		t.Errorf("UserTags is not correct, expect: %s got %s",
+			correctConfig.UserTags, otherConfig.UserTags)
+	}
 }
 
 func TestReadConfig(t *testing.T) {
@@ -200,9 +212,10 @@ func TestReadConfig(t *testing.T) {
 		SecurityGroupIds:      testSecurityGroup,
 		NewVPC:                testNewVPC,
 		IamInstanceProfile:    testIamProfile,
+		UserDataFilePath:      testUserDataFilePath,
+		UserTags:              testTags,
 	}
 
 	compareConfig(correctConfig, simpleConfig, t)
-
 	os.Remove(testConfigFilePath)
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
+	"reflect"
 	"strconv"
 	"testing"
 
@@ -67,12 +68,12 @@ const testLaunchTemplateId = "lt-12345"
 const testLaunchTemplateVersion = "1"
 const testNewVPC = true
 const testIamProfile = "iam-profile"
-const testUserDataFilePath = "some/path/to/userdata"
+const testBootScriptFilePath = "some/path/to/bootscript"
 
-var testTags = []string{"testedBy:BRYAN", "brokenBy:CBASKIN"}
+var testTags = map[string]string{"testedBy": "BRYAN", "brokenBy": "CBASKIN"}
 var testSecurityGroup = []string{"sg-12345", "sg-67890"}
 
-const expectedJson = `{"Region":"us-somewhere","ImageId":"ami-12345","InstanceType":"t2.micro","SubnetId":"s-12345","LaunchTemplateId":"lt-12345","LaunchTemplateVersion":"1","SecurityGroupIds":["sg-12345","sg-67890"],"NewVPC":true,"AutoTerminationTimerMinutes":0,"KeepEbsVolumeAfterTermination":false,"IamInstanceProfile":"iam-profile","UserDataFilePath":"some/path/to/userdata","UserTags":["testedBy:BRYAN","brokenBy:CBASKIN"]}`
+const expectedJson = `{"Region":"us-somewhere","ImageId":"ami-12345","InstanceType":"t2.micro","SubnetId":"s-12345","LaunchTemplateId":"lt-12345","LaunchTemplateVersion":"1","SecurityGroupIds":["sg-12345","sg-67890"],"NewVPC":true,"AutoTerminationTimerMinutes":0,"KeepEbsVolumeAfterTermination":false,"IamInstanceProfile":"iam-profile","BootScriptFilePath":"some/path/to/bootscript","UserTags":{"brokenBy":"CBASKIN","testedBy":"BRYAN"}}`
 
 func TestSaveConfig(t *testing.T) {
 	testConfig := &config.SimpleInfo{
@@ -85,7 +86,7 @@ func TestSaveConfig(t *testing.T) {
 		SecurityGroupIds:      testSecurityGroup,
 		NewVPC:                testNewVPC,
 		IamInstanceProfile:    testIamProfile,
-		UserDataFilePath:      testUserDataFilePath,
+		BootScriptFilePath:    testBootScriptFilePath,
 		UserTags:              testTags,
 	}
 
@@ -111,7 +112,7 @@ func TestSaveConfig(t *testing.T) {
 }
 
 func TestOverrideConfigWithFlags(t *testing.T) {
-	simpleConfig := &config.SimpleInfo{}
+	simpleConfig := config.NewSimpleInfo()
 	flagConfig := &config.SimpleInfo{
 		Region:                testRegion,
 		ImageId:               testImageId,
@@ -122,7 +123,7 @@ func TestOverrideConfigWithFlags(t *testing.T) {
 		SecurityGroupIds:      testSecurityGroup,
 		NewVPC:                testNewVPC,
 		IamInstanceProfile:    testIamProfile,
-		UserDataFilePath:      testUserDataFilePath,
+		BootScriptFilePath:    testBootScriptFilePath,
 		UserTags:              testTags,
 	}
 
@@ -177,11 +178,11 @@ func compareConfig(correctConfig, otherConfig *config.SimpleInfo, t *testing.T) 
 		t.Errorf("IamInstanceProfile is not correct, expect: %s got %s",
 			correctConfig.IamInstanceProfile, otherConfig.IamInstanceProfile)
 	}
-	if correctConfig.UserDataFilePath != otherConfig.UserDataFilePath {
-		t.Errorf("UserDataFilePath is not correct, expect: %s got %s",
-			correctConfig.UserDataFilePath, otherConfig.UserDataFilePath)
+	if correctConfig.BootScriptFilePath != otherConfig.BootScriptFilePath {
+		t.Errorf("BootScriptFilePath is not correct, expect: %s got %s",
+			correctConfig.BootScriptFilePath, otherConfig.BootScriptFilePath)
 	}
-	if !th.StringSliceEqual(correctConfig.UserTags, otherConfig.UserTags) {
+	if !reflect.DeepEqual(correctConfig.UserTags, otherConfig.UserTags) {
 		t.Errorf("UserTags is not correct, expect: %s got %s",
 			correctConfig.UserTags, otherConfig.UserTags)
 	}
@@ -194,7 +195,7 @@ func TestReadConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	simpleConfig := &config.SimpleInfo{}
+	simpleConfig := config.NewSimpleInfo()
 	err = config.ReadConfig(simpleConfig, aws.String(testConfigFileName))
 	if err != nil {
 		os.Remove(testConfigFilePath)
@@ -212,7 +213,7 @@ func TestReadConfig(t *testing.T) {
 		SecurityGroupIds:      testSecurityGroup,
 		NewVPC:                testNewVPC,
 		IamInstanceProfile:    testIamProfile,
-		UserDataFilePath:      testUserDataFilePath,
+		BootScriptFilePath:    testBootScriptFilePath,
 		UserTags:              testTags,
 	}
 

--- a/pkg/ec2helper/ec2helper_test.go
+++ b/pkg/ec2helper/ec2helper_test.go
@@ -1478,15 +1478,15 @@ func TestValidateFilepath_False(t *testing.T) {
 }
 
 func TestValidateTags_True(t *testing.T) {
-	testUserInput := "tag1:val1,tag2:val2"
+	testUserInput := "tag1|val1,tag2|val2"
 	result := ec2helper.ValidateTags(testEC2, testUserInput)
 	if !result {
-		t.Errorf("Incorrect image validation, expect: %t, got: %t", true, result)
+		t.Errorf("Incorrect tag validation, expect: %t, got: %t", true, result)
 	}
 }
 
 func TestValidateTags_False(t *testing.T) {
-	testUserInput := "tag1:val1,tag2:val2,tag3"
+	testUserInput := "tag1|val1,tag2|val2,tag3"
 	result := ec2helper.ValidateTags(testEC2, testUserInput)
 	if result {
 		t.Errorf("Incorrect image validation, expect: %t, got: %t", false, result)

--- a/pkg/ec2helper/ec2helper_test.go
+++ b/pkg/ec2helper/ec2helper_test.go
@@ -16,6 +16,7 @@ package ec2helper_test
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"testing"
 
@@ -1032,6 +1033,7 @@ const testSubnetId = "subnet-12345"
 const testVpcId = "vpc-12345"
 const testImageId = "ami-12345"
 const testInstanceType = "t2.micro"
+const testDeviceType = "ebs"
 
 var testSecurityGroupIds = []string{
 	"sg-12345",
@@ -1058,7 +1060,8 @@ var parseConfigSvc = &th.MockedEC2Svc{
 	},
 	Images: []*ec2.Image{
 		{
-			ImageId: aws.String(testImageId),
+			ImageId:        aws.String(testImageId),
+			RootDeviceType: aws.String(testDeviceType),
 		},
 	},
 	InstanceTypes: []*ec2.InstanceTypeInfo{
@@ -1426,7 +1429,7 @@ func TestGetTagName_NoResult(t *testing.T) {
 }
 
 /*
-Image Validation Tests
+Validation Tests
 */
 
 func TestValidateImageId_True(t *testing.T) {
@@ -1450,6 +1453,41 @@ func TestValidateImageId_False(t *testing.T) {
 	}
 
 	result := ec2helper.ValidateImageId(testEC2, testImageId)
+	if result {
+		t.Errorf("Incorrect image validation, expect: %t, got: %t", false, result)
+	}
+}
+
+func TestValidateFilepath_True(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "mocked_filepath")
+	defer os.Remove(tmpFile.Name())
+	if err != nil {
+		t.Errorf("There was an error creating tempfile: %v", err)
+	}
+	result := ec2helper.ValidateFilepath(testEC2, tmpFile.Name())
+	if !result {
+		t.Errorf("Incorrect filepath validation, expect: %t, got: %t", true, result)
+	}
+}
+
+func TestValidateFilepath_False(t *testing.T) {
+	result := ec2helper.ValidateFilepath(testEC2, "file/does/not/exist")
+	if result {
+		t.Errorf("Incorrect filepath validation, expect: %t, got: %t", false, result)
+	}
+}
+
+func TestValidateTags_True(t *testing.T) {
+	testUserInput := "tag1:val1,tag2:val2"
+	result := ec2helper.ValidateTags(testEC2, testUserInput)
+	if !result {
+		t.Errorf("Incorrect image validation, expect: %t, got: %t", true, result)
+	}
+}
+
+func TestValidateTags_False(t *testing.T) {
+	testUserInput := "tag1:val1,tag2:val2,tag3"
+	result := ec2helper.ValidateTags(testEC2, testUserInput)
 	if result {
 		t.Errorf("Incorrect image validation, expect: %t, got: %t", false, result)
 	}

--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -1014,6 +1014,13 @@ func AskConfirmationWithInput(simpleConfig *config.SimpleInfo, detailedConfig *c
 		data = append(data, []string{cli.ResourceIamInstanceProfile, simpleConfig.IamInstanceProfile})
 	}
 
+	if simpleConfig.UserDataFilePath != "" {
+		data = append(data, []string{cli.ResourceUserDataFilePath, simpleConfig.UserDataFilePath})
+	}
+	if simpleConfig.UserTags != nil {
+		data = append(data, []string{cli.ResourceUserTags, strings.Join(simpleConfig.UserTags, "\n")})
+	}
+
 	configText := table.BuildTable(data, nil)
 
 	optionsText := configText + yesNoOption + "\n"
@@ -1131,6 +1138,31 @@ func AskInstanceIds(h *ec2helper.EC2Helper, addedInstanceIds []string) (*string,
 	})
 
 	return &answer, err
+}
+
+// AskUserData prompts the user for a filepath to an optional boot script
+func AskUserData(h *ec2helper.EC2Helper) string {
+	question := "Add filepath to instance boot script? " + "\n" + "format: absolute file path"
+	answer := AskQuestion(&AskQuestionInput{
+		QuestionString: question,
+		DefaultOption:  aws.String(cli.ResponseNo),
+		EC2Helper:      h,
+		Fns:            []CheckInput{ec2helper.ValidateFilepath},
+	})
+	return answer
+}
+
+// AskUserTags prompts the user for optional tags
+func AskUserTags(h *ec2helper.EC2Helper) string {
+	question := "Add tags to instances and persisted volumes? " + "\n" + "format: tag1:val1,tag2:val2"
+
+	answer := AskQuestion(&AskQuestionInput{
+		QuestionString: question,
+		DefaultOption:  aws.String(cli.ResponseNo),
+		EC2Helper:      h,
+		Fns:            []CheckInput{ec2helper.ValidateTags},
+	})
+	return answer
 }
 
 // AskTerminationConfirmation confirms if the user wants to terminate the selected instanceIds

--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -1014,11 +1014,15 @@ func AskConfirmationWithInput(simpleConfig *config.SimpleInfo, detailedConfig *c
 		data = append(data, []string{cli.ResourceIamInstanceProfile, simpleConfig.IamInstanceProfile})
 	}
 
-	if simpleConfig.UserDataFilePath != "" {
-		data = append(data, []string{cli.ResourceUserDataFilePath, simpleConfig.UserDataFilePath})
+	if simpleConfig.BootScriptFilePath != "" {
+		data = append(data, []string{cli.ResourceBootScriptFilePath, simpleConfig.BootScriptFilePath})
 	}
 	if simpleConfig.UserTags != nil {
-		data = append(data, []string{cli.ResourceUserTags, strings.Join(simpleConfig.UserTags, "\n")})
+		var tags []string
+		for k, v := range simpleConfig.UserTags {
+			tags = append(tags, fmt.Sprintf("%s|%s", k, v))
+		}
+		data = append(data, []string{cli.ResourceUserTags, strings.Join(tags, "\n")})
 	}
 
 	configText := table.BuildTable(data, nil)
@@ -1140,8 +1144,8 @@ func AskInstanceIds(h *ec2helper.EC2Helper, addedInstanceIds []string) (*string,
 	return &answer, err
 }
 
-// AskUserData prompts the user for a filepath to an optional boot script
-func AskUserData(h *ec2helper.EC2Helper) string {
+// AskBootScript prompts the user for a filepath to an optional boot script
+func AskBootScript(h *ec2helper.EC2Helper) string {
 	question := "Add filepath to instance boot script? " + "\n" + "format: absolute file path"
 	answer := AskQuestion(&AskQuestionInput{
 		QuestionString: question,
@@ -1154,8 +1158,7 @@ func AskUserData(h *ec2helper.EC2Helper) string {
 
 // AskUserTags prompts the user for optional tags
 func AskUserTags(h *ec2helper.EC2Helper) string {
-	question := "Add tags to instances and persisted volumes? " + "\n" + "format: tag1:val1,tag2:val2"
-
+	question := "Add tags to instances and persisted volumes? " + "\n" + "format: tag1|val1,tag2|val2"
 	answer := AskQuestion(&AskQuestionInput{
 		QuestionString: question,
 		DefaultOption:  aws.String(cli.ResponseNo),

--- a/pkg/question/question_test.go
+++ b/pkg/question/question_test.go
@@ -842,7 +842,7 @@ func TestAskConfirmationWithTemplate_DescribeLaunchTemplateVersionsPagesError(t 
 		DescribeLaunchTemplateVersionsPagesError: errors.New("Test error"),
 	}
 
-	testSimpleConfig := &config.SimpleInfo{}
+	testSimpleConfig := config.NewSimpleInfo()
 
 	initQuestionTest(t, cli.ResponseYes+"\n")
 

--- a/pkg/tag/tag.go
+++ b/pkg/tag/tag.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Get the tags for resources created by simple-ec2
-func GetTags() *map[string]string {
+func GetSimpleEc2Tags() *map[string]string {
 	now := time.Now()
 	zone, _ := now.Zone()
 	nowString := fmt.Sprintf("%d-%d-%d %d:%d:%d %s", now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(),
@@ -29,6 +29,5 @@ func GetTags() *map[string]string {
 		"CreatedBy":   "simple-ec2",
 		"CreatedTime": nowString,
 	}
-
 	return &tags
 }

--- a/pkg/tag/tag_test.go
+++ b/pkg/tag/tag_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestGetTags(t *testing.T) {
-	tags := tag.GetTags()
+	tags := tag.GetSimpleEc2Tags()
 
 	createdBy, found := (*tags)["CreatedBy"]
 	if !found || createdBy != "simple-ec2" {


### PR DESCRIPTION
Issue #, if available: 
* N/A-- adding more functionality

Description of changes:
* users can now provide their own user data/boot script and tags:
  * `--boot-script` or `-b`
  * `--tags`
* added validations + unit tests
* don't worry-- [simple-ec2 tags](https://github.com/awslabs/aws-simple-ec2-cli/blob/main/pkg/tag/tag.go#L29) are still added to instances/volumes
* If users designate an `auto-termination-time` AND `boot-script`, the shutdown command will be prepended to the user's script

Testing:
* `make unit-test`
* `./build/simple-ec2 launch -i`
```
Add filepath to instance boot script? 
format: absolute file path
[Press enter to choose default: no]
Your Choice >> /Users/crtbry/workplace/go/src/simpleEc2_brycahta_fork_ws/aws-simple-ec2-cli/test-boot

Add tags to instances and persisted volumes? 
format: tag1:val1,tag2:val2
[Press enter to choose default: no]
Your Choice >> testedBy:Mee,reviewedBy:pdk

Please confirm if you would like to launch instance with following options: 

+--------------------------------------+----------------------------------------------------------------------------------------+
| Region                               | us-east-1                                                                              |
+--------------------------------------+----------------------------------------------------------------------------------------+
| VPC                                  | vpc-d295a6a8                                                                           |
+--------------------------------------+----------------------------------------------------------------------------------------+
| Subnet                               | subnet-0f0fd0423d9a6183e                                                               |
+--------------------------------------+----------------------------------------------------------------------------------------+
| Instance Type                        | t1.micro                                                                               |
+--------------------------------------+----------------------------------------------------------------------------------------+
| Image                                | ami-047a51fa27710816e                                                                  |
+--------------------------------------+----------------------------------------------------------------------------------------+
| Security Group                       | sg-819314ab                                                                            |
+--------------------------------------+----------------------------------------------------------------------------------------+
| Keep EBS Volume(s) After Termination | false                                                                                  |
+--------------------------------------+----------------------------------------------------------------------------------------+
| Auto Termination Timer in Minutes    | None                                                                                   |
+--------------------------------------+----------------------------------------------------------------------------------------+
| EBS Volumes                          | /dev/xvda(gp2): 8 GiB                                                                  |
+--------------------------------------+----------------------------------------------------------------------------------------+
| Boot Script Filepath                 | /Users/crtbry/workplace/go/src/simpleEc2_brycahta_fork_ws/aws-simple-ec2-cli/test-boot |
+--------------------------------------+----------------------------------------------------------------------------------------+
| Tag Specification                    | testedBy:Mee                                                                           |
|                                      | reviewedBy:pdk                                                                         |
+--------------------------------------+----------------------------------------------------------------------------------------+

```

  * `>cat test-boot`:
```
#!/bin/bash 
    echo "sudo poweroff" | at now + 5 minutes
```
  * ✅   user script took effect & instance shutdown as expected


* `./build/simple-ec2 launch -b /Users/crtbry/workplace/go/src/simpleEc2_brycahta_fork_ws/aws-simple-ec2-cli/test-boot-2 --tags createdBy:Bryan,reviewedBy:PdK --region us-east-1 -a 3`
```
Please confirm if you would like to launch instance with following options: 

+--------------------------------------+------------------------------------------------------------------------------------------+
| Region                               | us-east-1                                                                                |
+--------------------------------------+------------------------------------------------------------------------------------------+
| VPC                                  | vpc-d295a6a8                                                                             |
+--------------------------------------+------------------------------------------------------------------------------------------+
| Subnet                               | subnet-0f0fd0423d9a6183e                                                                 |
+--------------------------------------+------------------------------------------------------------------------------------------+
| Instance Type                        | t1.micro                                                                                 |
+--------------------------------------+------------------------------------------------------------------------------------------+
| Image                                | ami-047a51fa27710816e                                                                    |
+--------------------------------------+------------------------------------------------------------------------------------------+
| Security Group                       | sg-819314ab                                                                              |
+--------------------------------------+------------------------------------------------------------------------------------------+
| Keep EBS Volume(s) After Termination | false                                                                                    |
+--------------------------------------+------------------------------------------------------------------------------------------+
| Auto Termination Timer in Minutes    | 3                                                                                        |
+--------------------------------------+------------------------------------------------------------------------------------------+
| EBS Volumes                          | /dev/xvda(gp2): 8 GiB                                                                    |
+--------------------------------------+------------------------------------------------------------------------------------------+
| Boot Script Filepath                 | /Users/crtbry/workplace/go/src/simpleEc2_brycahta_fork_ws/aws-simple-ec2-cli/test-boot-2 |
+--------------------------------------+------------------------------------------------------------------------------------------+
| Tag Specification                    | createdBy:Bryan                                                                          |
|                                      | reviewedBy:PdK                                                                           |
+--------------------------------------+------------------------------------------------------------------------------------------+
```

  * `>cat test-boot-2`:
```
echo "yada yada"
echo "still testing ish"
```
  * ✅   user script took effect & auto-termination-timer was applied & instance shutdown as expected


* `./build/simple-ec2 launch -h`
```
Launch an Amazon EC2 instance with the default configurations. All configurations can be overridden by configurations provided by configuration files or user input.

Usage:
  simple-ec2 launch [flags]

Flags:
  -a, --auto-termination-timer int       The auto-termination timer for the instance in minutes
  -b, --boot-script string               The absolute filepath to a bash script passed to the instance and executed after the instance starts (user data)
  -h, --help                             help for launch
  -p, --iam-instance-profile string      The profile containing an IAM role to attach to the instance
  -m, --image-id string                  The image id of the AMI used to launch the instance
  -t, --instance-type string             The instance type of the instance
  -i, --interactive                      Interactive mode
  -k, --keep-ebs                         Keep EBS volumes after instance termination
  -l, --launch-template-id string        The launch template id with which the instance will be launched
  -v, --launch-template-version string   The launch template version with which the instance will be launched
  -r, --region string                    The region where the instance will be launched
  -c, --save-config                      Save config as a JSON config file
  -g, --security-group-ids strings       The security groups with which the instance will be launched
  -s, --subnet-id string                 The subnet id in which the instance will be launched
      --tags strings                     The tags applied to instances and volumes at launch
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
