### PR TITLE
terminate using tags

### DIFF
--- a/cmd/terminate.go
+++ b/cmd/terminate.go
@@ -121,7 +121,10 @@ func terminateNonInteractive(h *ec2helper.EC2Helper) {
 		return
 	}
 
-	cli.ShowError(h.TerminateInstances(instancesToTerm), "Terminating instances failed")
+	err = h.TerminateInstances(instancesToTerm)
+	if err != nil {
+		cli.ShowError(err, "Terminating instances failed")
+	}
 }
 
 // Validate flags using some simple rules. Return true if the flags are validated, false otherwise

--- a/pkg/ec2helper/ec2helper.go
+++ b/pkg/ec2helper/ec2helper.go
@@ -871,6 +871,31 @@ func (h *EC2Helper) GetInstancesByState(states []string) ([]*ec2.Instance, error
 	return instances, nil
 }
 
+func (h *EC2Helper) GetInstancesByFilter(instanceIds []string, filters []*ec2.Filter) ([]string, error) {
+	input := &ec2.DescribeInstancesInput{}
+	if len(instanceIds) > 0 {
+		input.InstanceIds = aws.StringSlice(instanceIds)
+	}
+	if len(filters) > 0 {
+		input.Filters = filters
+	}
+
+	instances, err := h.getInstances(input)
+	if err != nil {
+		return nil, err
+	}
+	if len(instances) <= 0 {
+		return nil, nil
+	}
+
+	var result []string
+	for _, instance := range instances {
+		result = append(result, *instance.InstanceId)
+	}
+
+	return result, nil
+}
+
 // Create tags for the resources specified
 func (h *EC2Helper) createTags(resources []string, tags []*ec2.Tag) error {
 	input := &ec2.CreateTagsInput{
@@ -1239,7 +1264,6 @@ func GetTagName(tags []*ec2.Tag) *string {
 			return tag.Value
 		}
 	}
-
 	return nil
 }
 

--- a/pkg/ec2helper/ec2helper_test.go
+++ b/pkg/ec2helper/ec2helper_test.go
@@ -1033,26 +1033,17 @@ func TestGetInstancesByFilter_Success(t *testing.T) {
 	testEC2.Svc = &th.MockedEC2Svc{
 		Instances: testInstances,
 	}
-
 	testFilters := []*ec2.Filter{
 		{
 			Name:   aws.String("tag:TestedBy"),
 			Values: aws.StringSlice([]string{"meh"}),
 		},
 	}
+	actualInstances, err := testEC2.GetInstancesByFilter([]string{"i-12345", "i-67890"}, testFilters)
 
-	instances, err := testEC2.GetInstancesByFilter([]string{"i-12345", "i-67890"}, testFilters)
-	if err != nil {
-		t.Errorf(th.UnexpectedErrorFormat, err)
-	}
-	if len(instances) != 1 {
-		t.Error("Incorrect instance(s) returned after filtering")
-		fmt.Printf("instances: %v\n", instances)
-	} else {
-		if instances[0] != "i-12345" {
-			t.Error("Incorrect instance(s) returned after filtering")
-		}
-	}
+	th.Ok(t, err)
+	th.Assert(t, len(actualInstances) == 1, "Incorrect instance(s) returned after filtering")
+	th.Assert(t, actualInstances[0] == "i-12345", "Incorrect instance(s) returned after filtering")
 }
 
 func TestGetInstancesByFilter_NoResults(t *testing.T) {
@@ -1075,12 +1066,9 @@ func TestGetInstancesByFilter_NoResults(t *testing.T) {
 		},
 	}
 
-	instances, err := testEC2.GetInstancesByFilter([]string{"i-12345", "i-67890"}, testFilters)
-	if err != nil {
-		t.Errorf(th.UnexpectedErrorFormat, err)
-	} else if len(instances) != 0 {
-		t.Error("Instances should NOT have been returned after filtering")
-	}
+	actualInstances, err := testEC2.GetInstancesByFilter([]string{"i-12345", "i-67890"}, testFilters)
+	th.Ok(t, err)
+	th.Assert(t, len(actualInstances) == 0, "Instances should NOT have been returned after filtering")
 }
 
 func TestGetInstancesByState_DescribeInstancesPagesError(t *testing.T) {

--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -1015,7 +1015,7 @@ func AskConfirmationWithInput(simpleConfig *config.SimpleInfo, detailedConfig *c
 	if simpleConfig.BootScriptFilePath != "" {
 		data = append(data, []string{cli.ResourceBootScriptFilePath, simpleConfig.BootScriptFilePath})
 	}
-	if simpleConfig.UserTags != nil {
+	if len(simpleConfig.UserTags) != 0 {
 		var tags []string
 		for k, v := range simpleConfig.UserTags {
 			tags = append(tags, fmt.Sprintf("%s|%s", k, v))

--- a/pkg/tag/tag.go
+++ b/pkg/tag/tag.go
@@ -16,6 +16,9 @@ package tag
 import (
 	"fmt"
 	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
 // Get the tags for resources created by simple-ec2
@@ -30,4 +33,15 @@ func GetSimpleEc2Tags() *map[string]string {
 		"CreatedTime": nowString,
 	}
 	return &tags
+}
+
+// Convert tag map to Filter
+func GetTagAsFilter(userTags map[string]string) (filters []*ec2.Filter, err error) {
+	for k, v := range userTags {
+		filters = append(filters, &ec2.Filter{
+			Name:   aws.String("tag:" + k), //prepend tag: for exact matching
+			Values: aws.StringSlice([]string{v}),
+		})
+	}
+	return filters, nil
 }

--- a/test/testhelper/testhelper.go
+++ b/test/testhelper/testhelper.go
@@ -14,8 +14,13 @@
 package testhelper
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -137,4 +142,40 @@ func RestoreStdin() {
 
 	tmpFile.Close()
 	os.Remove(tmpFile.Name())
+}
+
+// Assert fails the test if the condition is false.
+func Assert(tb testing.TB, condition bool, msg string, v ...interface{}) {
+	if !condition {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d: "+msg+"\033[39m\n\n", append([]interface{}{filepath.Base(file), line}, v...)...)
+		tb.FailNow()
+	}
+}
+
+// Ok fails the test if an err is not nil.
+func Ok(tb testing.TB, err error) {
+	if err != nil {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d: unexpected error: %s\033[39m\n\n", filepath.Base(file), line, err.Error())
+		tb.FailNow()
+	}
+}
+
+// Nok fails the test if an err is nil.
+func Nok(tb testing.TB, err error) {
+	if err == nil {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d: unexpected success \033[39m\n\n", filepath.Base(file), line)
+		tb.FailNow()
+	}
+}
+
+// Equals fails the test if exp is not equal to act.
+func Equals(tb testing.TB, exp, act interface{}) {
+	if !reflect.DeepEqual(exp, act) {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\033[39m\n\n", filepath.Base(file), line, exp, act)
+		tb.FailNow()
+	}
 }


### PR DESCRIPTION
Issue #, if available:
* N/A

Description of changes:
* Users can now terminate instances by tag `key:pair` value(s)! 🎉
* `simple-ec2 terminate --tags tag1=val1` --> terminates ALL instances containing `tag1:val1` tags
*  `simple-ec2 terminate -n instanceId1,instanceId2 --tags tag1=val1` --> terminates instances at the intersection of instanceId and tags
* Updated tests + mocks

Testing:
* Tested both use cases locally (with and without instanceId) and saw expected functionality
* `make unit-test` pass
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
