### PR TITLE
fix launch without region flag

### DIFF
--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -222,9 +222,8 @@ func launchNonInteractive(h *ec2helper.EC2Helper) {
 	simpleConfig := config.NewSimpleInfo()
 	if flagConfig.Region != "" {
 		simpleConfig.Region = flagConfig.Region
+		h.ChangeRegion(simpleConfig.Region)
 	}
-
-	h.ChangeRegion(simpleConfig.Region)
 
 	// Try to get config from the config file
 	err := config.ReadConfig(simpleConfig, nil)

--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -1026,7 +1026,7 @@ func AskConfirmationWithInput(simpleConfig *config.SimpleInfo, detailedConfig *c
 	configText := table.BuildTable(data, nil)
 
 	optionsText := configText + yesNoOption + "\n"
-	question := "Please confirm if you would like to launch instance with following options: "
+	question := "Please confirm if you would like to launch instance with following options"
 
 	answer := AskQuestion(&AskQuestionInput{
 		QuestionString: question,


### PR DESCRIPTION
Issue #, if available:
* N/A, noticed some minor issues

Description of changes:
1. ReadMe says `>simple-ec2 launch` is valid; however, the current code will always set region to be "" and the program will exit
2. Confirmation prompt wasn't formatted properly

Testing:
* `make unit-test`

Confirmation prompt Before/After:
* Before: `Please confirm if you would like to launch instance with following options: : `
* After: `Please confirm if you would like to launch instance with following options: `

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
