### PR TITLE
Add CODEOWNERS to strengthen branch protections

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# Require approvals from someone in the owner team before merging
+# More information here: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @awslabs/ec2-guacamole


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes: Add a codeowners file that includes the owning group within the AWSLabs org. Once merged, we'll enable "Require review from Code Owners" in the branch protection settings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
