### PR TITLE
Fix release script prompt when calling from a golang program

### DIFF
--- a/scripts/prepare-for-release
+++ b/scripts/prepare-for-release
@@ -178,7 +178,8 @@ EOM
     # gh actions cannot respond to prompts
     if [[ $RELEASE_PREP == true ]]; then
       while true; do
-          read -p "🥑${BOLD}Do you wish to create the release prep PR? Enter y/n  " yn
+          echo -e "🥑${BOLD}Do you wish to create the release prep PR? Enter y/n"
+          read -p "" yn
           case $yn in
               [Yy]* ) create_pr; break;;
               [Nn]* ) rollback; exit;;


### PR DESCRIPTION


**Issue #, if available:** N/A

**Description of changes:**

For some reason, `read -p` doesn't properly print to stdout when invoked via golang's `exec.Command().Run()`, but `echo` does. Reading from stdin still works correctly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
