### PR TITLE
Update go version and specify some library versions in Dockerfiles

### DIFF
--- a/test/license-test/Dockerfile
+++ b/test/license-test/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1
+FROM golang:1.16
 
 WORKDIR /app
 
 COPY license-config.hcl .
 ARG GOPROXY="https://proxy.golang.org,direct"
-RUN GO111MODULE=on go get github.com/mitchellh/golicense
+RUN GO111MODULE=on go install github.com/mitchellh/golicense@v0.2.0
 
 CMD $GOPATH/bin/golicense 

--- a/test/license-test/gen-license-report.sh
+++ b/test/license-test/gen-license-report.sh
@@ -6,7 +6,7 @@ BUILD_DIR="$SCRIPTPATH/../../build"
 mkdir -p $BUILD_DIR
 export PATH="$PATH:$(go env GOPATH | sed 's+:+/bin+g')/bin"
 
-go get github.com/mitchellh/golicense
+go install github.com/mitchellh/golicense@v0.2.0
 make -s -f $SCRIPTPATH/../../Makefile compile 
 golicense -out-xlsx=$BUILD_DIR/report.xlsx $SCRIPTPATH/license-config.hcl $BUILD_DIR/aws-simple-ec2-cli
 

--- a/test/readme-test/run-readme-spellcheck
+++ b/test/readme-test/run-readme-spellcheck
@@ -9,6 +9,6 @@ function exit_and_fail() {
 }
 trap exit_and_fail INT ERR TERM
 
-docker build -t misspell -f $SCRIPTPATH/spellcheck-Dockerfile $SCRIPTPATH/
+docker build --build-arg="GOPROXY=direct" -t misspell -f $SCRIPTPATH/spellcheck-Dockerfile $SCRIPTPATH/
 docker run -i --rm -v $SCRIPTPATH/../../:/aeis misspell /bin/bash -c 'find /aeis/ -type f -name "*.md" -not -path "build" | grep -v "/build/" | xargs misspell -error -debug'
 echo "✅ Markdown file spell check passed!"

--- a/test/readme-test/spellcheck-Dockerfile
+++ b/test/readme-test/spellcheck-Dockerfile
@@ -1,5 +1,6 @@
-FROM golang:1
+FROM golang:1.16
 
-RUN go get -u github.com/client9/misspell/cmd/misspell
+ARG GOPROXY="https://proxy.golang.org,direct"
+RUN go install github.com/client9/misspell/cmd/misspell@v0.3.4
 
 CMD [ "/go/bin/misspell" ]


### PR DESCRIPTION
This will prevent build failures related to deprecation of `go get` in go 1.18.

Issue #, if available: N/A

Description of changes:

Fix some build failures, similar to this PR in another repo that has a similar structure: https://github.com/aws/aws-node-termination-handler/pull/605

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
