### PR TITLE
Show AMI images based on the type of ec2 instance type chosen

### DIFF
--- a/pkg/ec2helper/ec2helper_test.go
+++ b/pkg/ec2helper/ec2helper_test.go
@@ -455,13 +455,13 @@ func TestGetLatestImages_Success_Ebs(t *testing.T) {
 		Images: testImages,
 	}
 
-	actualImages, err := testEC2.GetLatestImages(nil)
+	actualImages, err := testEC2.GetLatestImages(nil, aws.StringSlice([]string{"x86_64"}))
 	th.Ok(t, err)
 	th.Equals(t, testMapEbs, *actualImages)
 }
 
 func TestGetLatestImages_Success_InstanceStore(t *testing.T) {
-	actualImages, err := testEC2.GetLatestImages(aws.String("instance-store"))
+	actualImages, err := testEC2.GetLatestImages(aws.String("instance-store"), aws.StringSlice([]string{"x86_64"}))
 	th.Ok(t, err)
 	th.Equals(t, testMapInstanceStore, *actualImages)
 }
@@ -471,7 +471,7 @@ func TestGetLatestImages_NoResult(t *testing.T) {
 		Images: []*ec2.Image{},
 	}
 
-	_, err := testEC2.GetLatestImages(nil)
+	_, err := testEC2.GetLatestImages(nil, aws.StringSlice([]string{"x86_64"}))
 	th.Ok(t, err)
 }
 
@@ -480,7 +480,7 @@ func TestGetLatestImages_DescribeImagesError(t *testing.T) {
 		DescribeImagesError: errors.New("Test error"),
 	}
 
-	_, err := testEC2.GetLatestImages(nil)
+	_, err := testEC2.GetLatestImages(nil, aws.StringSlice([]string{"x86_64"}))
 	th.Nok(t, err)
 }
 
@@ -489,7 +489,7 @@ func TestGetDefaultImage_Success(t *testing.T) {
 		Images: testImages,
 	}
 
-	actualImage, err := testEC2.GetDefaultImage(nil)
+	actualImage, err := testEC2.GetDefaultImage(nil, aws.StringSlice([]string{"x86_64"}))
 	th.Ok(t, err)
 	th.Equals(t, *lastImage.ImageId, *actualImage.ImageId)
 }
@@ -499,7 +499,7 @@ func TestGetDefaultImage_NoResult(t *testing.T) {
 		Images: []*ec2.Image{},
 	}
 
-	_, err := testEC2.GetDefaultImage(nil)
+	_, err := testEC2.GetDefaultImage(nil, aws.StringSlice([]string{"x86_64"}))
 	th.Nok(t, err)
 }
 
@@ -508,7 +508,7 @@ func TestGetDefaultImage_DescribeImagesError(t *testing.T) {
 		DescribeImagesError: errors.New("Test error"),
 	}
 
-	_, err := testEC2.GetDefaultImage(nil)
+	_, err := testEC2.GetDefaultImage(nil, aws.StringSlice([]string{"x86_64"}))
 	th.Nok(t, err)
 }
 

--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -440,7 +440,7 @@ func AskImage(h *ec2helper.EC2Helper, instanceType string) (*ec2.Image, error) {
 	s.Suffix = " fetching images"
 	s.Color("blue", "bold")
 	s.Start()
-	defaultImages, err := h.GetLatestImages(&rootDeviceType)
+	defaultImages, err := h.GetLatestImages(&rootDeviceType,instanceTypeInfo.ProcessorInfo.SupportedArchitectures)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/e2e-ec2helper-test/e2e_ec2helper_test.go
+++ b/test/e2e/e2e-ec2helper-test/e2e_ec2helper_test.go
@@ -152,14 +152,22 @@ func TestGetInstanceTypesFromInstanceSelector(t *testing.T) {
 func TestGetLatestImages(t *testing.T) {
 	th.Assert(t, h != nil, "EC2Helper was not initialized successfully")
 
-	_, err := h.GetLatestImages(nil)
+	_, err := h.GetLatestImages(nil, aws.StringSlice([]string{"x86_64"}))
 	th.Ok(t, err)
 }
 
-func TestGetDefaultImage(t *testing.T) {
+func TestGetDefaultImageForAmd(t *testing.T) {
 	th.Assert(t, h != nil, "EC2Helper was not initialized successfully")
 
-	image, err := h.GetDefaultImage(nil)
+	image, err := h.GetDefaultImage(nil, aws.StringSlice([]string{"x86_64"}))
+	th.Ok(t, err)
+	th.Assert(t, image != nil, "Image should not be nil")
+}
+
+func TestGetDefaultImageForArm(t *testing.T) {
+	th.Assert(t, h != nil, "EC2Helper was not initialized successfully")
+
+	image, err := h.GetDefaultImage(nil, aws.StringSlice([]string{"arm64"}))
 	th.Ok(t, err)
 	th.Assert(t, image != nil, "Image should not be nil")
 }


### PR DESCRIPTION
Issue #, if available:
https://github.com/awslabs/aws-simple-ec2-cli/issues/52

Description of changes:
Select images based on the architecture of ec2 instance to be used

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
