### PR TITLE
Make tables easier to read: remove separators between rows

### DIFF
--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -32,7 +32,6 @@ func BuildTable(data [][]string, header []string) string {
 	table := tablewriter.NewWriter(tableBuilder)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetAutoWrapText(false)
-	table.SetRowLine(true)
 
 	// Fill the table with data
 	for _, v := range data {


### PR DESCRIPTION

Issue #, if available: N/A

Description of changes:

Remove the separator printed between each row of a table. This makes headers more visible and reduces the vertical space needed to read an entire table.

Before (with row separators):

```
$ simple-ec2 launch -i

+--------+----------------+---------------------------+
| OPTION |     REGION     |        DESCRIPTION        |
+--------+----------------+---------------------------+
| 1.     | ap-northeast-1 | Asia Pacific (Tokyo)      |
+--------+----------------+---------------------------+
| 2.     | ap-northeast-2 | Asia Pacific (Seoul)      |
+--------+----------------+---------------------------+
| 3.     | ap-northeast-3 | Asia Pacific (Osaka)      |
+--------+----------------+---------------------------+
| 4.     | ap-south-1     | Asia Pacific (Mumbai)     |
+--------+----------------+---------------------------+
| 5.     | ap-southeast-1 | Asia Pacific (Singapore)  |
+--------+----------------+---------------------------+
| 6.     | ap-southeast-2 | Asia Pacific (Sydney)     |
+--------+----------------+---------------------------+
| 7.     | ca-central-1   | Canada (Central)          |
+--------+----------------+---------------------------+
| 8.     | eu-central-1   | Europe (Frankfurt)        |
+--------+----------------+---------------------------+
| 9.     | eu-north-1     | Europe (Stockholm)        |
+--------+----------------+---------------------------+
| 10.    | eu-west-1      | Europe (Ireland)          |
+--------+----------------+---------------------------+
| 11.    | eu-west-2      | Europe (London)           |
+--------+----------------+---------------------------+
| 12.    | eu-west-3      | Europe (Paris)            |
+--------+----------------+---------------------------+
| 13.    | sa-east-1      | South America (Sao Paulo) |
+--------+----------------+---------------------------+
| 14.    | us-east-1      | US East (N. Virginia)     |
+--------+----------------+---------------------------+
| 15.    | us-east-2      | US East (Ohio)            |
+--------+----------------+---------------------------+
| 16.    | us-west-1      | US West (N. California)   |
+--------+----------------+---------------------------+
| 17.    | us-west-2      | US West (Oregon)          |
+--------+----------------+---------------------------+
```

After (without row separators):

```
$ simple-ec2 launch -i

+--------+----------------+---------------------------+
| OPTION |     REGION     |        DESCRIPTION        |
+--------+----------------+---------------------------+
| 1.     | ap-northeast-1 | Asia Pacific (Tokyo)      |
| 2.     | ap-northeast-2 | Asia Pacific (Seoul)      |
| 3.     | ap-northeast-3 | Asia Pacific (Osaka)      |
| 4.     | ap-south-1     | Asia Pacific (Mumbai)     |
| 5.     | ap-southeast-1 | Asia Pacific (Singapore)  |
| 6.     | ap-southeast-2 | Asia Pacific (Sydney)     |
| 7.     | ca-central-1   | Canada (Central)          |
| 8.     | eu-central-1   | Europe (Frankfurt)        |
| 9.     | eu-north-1     | Europe (Stockholm)        |
| 10.    | eu-west-1      | Europe (Ireland)          |
| 11.    | eu-west-2      | Europe (London)           |
| 12.    | eu-west-3      | Europe (Paris)            |
| 13.    | sa-east-1      | South America (Sao Paulo) |
| 14.    | us-east-1      | US East (N. Virginia)     |
| 15.    | us-east-2      | US East (Ohio)            |
| 16.    | us-west-1      | US West (N. California)   |
| 17.    | us-west-2      | US West (Oregon)          |
+--------+----------------+---------------------------+
```

Note that this reverses a change from https://github.com/awslabs/aws-simple-ec2-cli/pull/22, which is part of 0.7.0. I've been using 0.6.0 (the latest version available in Homebrew), which does not have row separators, and I find it much easier to read. But if you have good reasons for why we should keep the row separators, please let me know.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
