### PR TITLE
Spotinstances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 .DS_Store
 */.DS_Store
 .vscode
+.idea

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ Flags:
   -g, --security-group-ids strings       The security groups with which the instance will be launched
   -s, --subnet-id string                 The subnet id in which the instance will be launched
       --tags stringToString              The tags applied to instances and volumes at launch (Example: tag1=val1,tag2=val2) (default [])
-  -x, --spot-price float                 The price at which spot instances
-  -z  --purchase-instance-type string    The purchase instance type of EC2 Instance. Values can be either OnDemand or SpotInstance
+      --spot-price float                 The price at which spot instances
+      --purchase-instance-type string    The purchase instance type of EC2 Instance. Values can be either OnDemand or SpotInstance
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -105,12 +105,18 @@ Flags:
   -g, --security-group-ids strings       The security groups with which the instance will be launched
   -s, --subnet-id string                 The subnet id in which the instance will be launched
       --tags stringToString              The tags applied to instances and volumes at launch (Example: tag1=val1,tag2=val2) (default [])
+  -x, --spot-price float                 The price at which spot instances
+  -z  --purchase-instance-type string    The purchase instance type of EC2 Instance. Values can be either OnDemand or SpotInstance
+
 ```
 
 **Single Command Launch**
 ```
 $ simple-ec2 launch
-
++--------------------------------------+--------------------------+
+| Ec2 Purchase Instance Type           | OnDemand|SpotInstance    |
++--------------------------------------+--------------------------+
+| Spot Instance Price (optional)       | 0.03                     |
 +--------------------------------------+--------------------------+
 | Region                               | us-east-1                |
 +--------------------------------------+--------------------------+
@@ -141,8 +147,10 @@ Instance ID: i-123example
 **Single Command Launch With Flags**
 
 ```
-$ simple-ec2 launch -r us-east-2 -m ami-123example -t t2.micro -s subnet-123example -g sg-123example
+$ simple-ec2 launch -r us-east-2 -m ami-123example -t t2.micro -s subnet-123example -g sg-123example -z OnDemand
 
++--------------------------------------+--------------------------+
+| Ec2 Purchase Instance Type           | OnDemand                |
 +--------------------------------------+--------------------------+
 | Region                               | us-east-2                |
 +--------------------------------------+--------------------------+

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -16,8 +16,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials/processcreds"
 	"os"
 	"strconv"
 	"strings"
@@ -83,14 +81,7 @@ func launch(cmd *cobra.Command, args []string) {
 	}
 
 	// Start a new session, with the default credentials and config loading
-	creds := processcreds.NewCredentials("isengardcli credentials --awscli --role Admin carthick+webeip1@amazon.com")
-	sess, err := session.NewSession(&aws.Config{
-		Region:      aws.String("us-east-1"),
-		Credentials: creds,
-	})
-	if err != nil {
-		fmt.Println("Could not get creads")
-	}
+	sess := session.Must(session.NewSessionWithOptions(session.Options{SharedConfigState: session.SharedConfigEnable}))
 	ec2helper.GetDefaultRegion(sess)
 	h := ec2helper.New(sess)
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -27,6 +27,8 @@ const (
 
 // Enum values for displaying resource types in CLI
 const (
+	Ec2PurchanceInstanceType         = "Ec2 Purchase Instance Type"
+	SpotInstancePrice         		 = "Spot Instance Price"
 	ResourceRegion                   = "Region"
 	ResourceVpc                      = "VPC"
 	ResourceSubnet                   = "Subnet"

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -27,7 +27,7 @@ const (
 
 // Enum values for displaying resource types in CLI
 const (
-	Ec2PurchanceInstanceType         = "Ec2 Purchase Instance Type"
+	Ec2PurchanceInstanceType         = "EC2 Purchase Instance Type"
 	SpotInstancePrice         		 = "Spot Instance Price"
 	ResourceRegion                   = "Region"
 	ResourceVpc                      = "VPC"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,8 +35,8 @@ A simple config for reading config files or flags into primitive type informatio
 The config will later be used to parse into a detailed config and to launch an instance.
 */
 type SimpleInfo struct {
-	Ec2PurchaseInstanceType       Ec2PurchseInstanceType
-	SpotInstancePrice 			  float64
+	EC2PurchaseInstanceType EC2PurchseInstanceType
+	SpotInstancePrice       float64
 	Region                        string
 	ImageId                       string
 	InstanceType                  string
@@ -52,30 +52,30 @@ type SimpleInfo struct {
 	UserTags                      map[string]string
 }
 
-type Ec2PurchseInstanceType string
+type EC2PurchseInstanceType string
 
 
-func ToPurchaseInstanceType(enumString string) Ec2PurchseInstanceType{
+func ToPurchaseInstanceType(enumString string) EC2PurchseInstanceType {
 	if enumString == "SpotInstance"{
 		return SpotInstance
 	}
 	return OnDemand
 }
 const (
-	OnDemand Ec2PurchseInstanceType = "OnDemand"
-	SpotInstance Ec2PurchseInstanceType = "SpotInstance"
+	OnDemand     EC2PurchseInstanceType = "OnDemand"
+	SpotInstance EC2PurchseInstanceType = "SpotInstance"
 )
 
 // String is used both by fmt.Print and by Cobra in help text
-func (e *Ec2PurchseInstanceType) String() string {
+func (e *EC2PurchseInstanceType) String() string {
 	return string(*e)
 }
 
 // Set must have pointer receiver so it doesn't change the value of a copy
-func (e *Ec2PurchseInstanceType) Set(v string) error {
+func (e *EC2PurchseInstanceType) Set(v string) error {
 	switch v {
 	case "OnDemand", "SpotInstance":
-		*e = Ec2PurchseInstanceType(v)
+		*e = EC2PurchseInstanceType(v)
 		return nil
 	default:
 		return errors.New(`must be one of "SpotInstance", "OnDemand"`)
@@ -83,7 +83,7 @@ func (e *Ec2PurchseInstanceType) Set(v string) error {
 }
 
 // Type is only used in help text
-func (e *Ec2PurchseInstanceType) Type() string {
+func (e *EC2PurchseInstanceType) Type() string {
 	return "OnDemand"
 }
 /*
@@ -141,13 +141,13 @@ func OverrideConfigWithFlags(simpleConfig *SimpleInfo, flagConfig *SimpleInfo) {
 	if flagConfig.Region != "" {
 		simpleConfig.Region = flagConfig.Region
 	}
-	if flagConfig.Ec2PurchaseInstanceType != "" {
-		simpleConfig.Ec2PurchaseInstanceType = flagConfig.Ec2PurchaseInstanceType
+	if flagConfig.EC2PurchaseInstanceType != "" {
+		simpleConfig.EC2PurchaseInstanceType = flagConfig.EC2PurchaseInstanceType
 	}
 	if flagConfig.SpotInstancePrice != 0 {
 		simpleConfig.SpotInstancePrice = flagConfig.SpotInstancePrice
 	}
-	if flagConfig.Ec2PurchaseInstanceType == SpotInstance{
+	if flagConfig.EC2PurchaseInstanceType == SpotInstance{
 		flagConfig.LaunchTemplateVersion = ""
 		flagConfig.LaunchTemplateId = ""
 		flagConfig.AutoTerminationTimerMinutes = 0

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,13 +54,15 @@ type SimpleInfo struct {
 
 type EC2PurchseInstanceType string
 
-
+// ToPurchaseInstanceType Sets the default purchase instance type to On Demand EC2 Instances, if purchase-instance-type flag's
+// value entered by the user does not match either "OnDemand or SpotInstance"
 func ToPurchaseInstanceType(enumString string) EC2PurchseInstanceType {
 	if enumString == "SpotInstance"{
 		return SpotInstance
 	}
 	return OnDemand
 }
+
 const (
 	OnDemand     EC2PurchseInstanceType = "OnDemand"
 	SpotInstance EC2PurchseInstanceType = "SpotInstance"
@@ -150,7 +152,6 @@ func OverrideConfigWithFlags(simpleConfig *SimpleInfo, flagConfig *SimpleInfo) {
 	if flagConfig.EC2PurchaseInstanceType == SpotInstance{
 		flagConfig.LaunchTemplateVersion = ""
 		flagConfig.LaunchTemplateId = ""
-		flagConfig.AutoTerminationTimerMinutes = 0
 	}
 	if flagConfig.InstanceType != "" {
 		simpleConfig.InstanceType = flagConfig.InstanceType

--- a/pkg/ec2helper/ec2helper_test.go
+++ b/pkg/ec2helper/ec2helper_test.go
@@ -1154,6 +1154,15 @@ var testDetailedConfig = config.DetailedInfo{
 	},
 }
 
+func TestRequestSpotInstance_Success_NoTemplate(t *testing.T) {
+	testEC2.Svc = launchSvc
+	testSimpleConfig.AutoTerminationTimerMinutes = 5
+	testSimpleConfig.KeepEbsVolumeAfterTermination = true
+
+	_, err := testEC2.RequestSpotInstance(&testSimpleConfig, &testDetailedConfig)
+	th.Ok(t, err)
+}
+
 func TestLaunchInstance_Success_NoTemplate(t *testing.T) {
 	testEC2.Svc = launchSvc
 	testSimpleConfig.AutoTerminationTimerMinutes = 5
@@ -1183,9 +1192,18 @@ func TestLaunchInstance_NoConfig(t *testing.T) {
 }
 
 func TestLaunchInstance_RunInstancesError(t *testing.T) {
+	testEC2.Svc = launchSvc
 	launchSvc.RunInstancesError = errors.New("Test error")
 
 	_, err := testEC2.LaunchInstance(&testSimpleConfig, &testDetailedConfig, true)
+	th.Nok(t, err)
+}
+
+func TestLaunchSpotInstance_RunSpotInstanceRequestError(t *testing.T) {
+	testEC2.Svc = launchSvc
+	launchSvc.SpotInstanceRequestError = errors.New("Test error")
+
+	_, err := testEC2.RequestSpotInstance(&testSimpleConfig, &testDetailedConfig)
 	th.Nok(t, err)
 }
 

--- a/pkg/ec2helper/types.go
+++ b/pkg/ec2helper/types.go
@@ -36,6 +36,9 @@ type EC2Svc interface {
 	RunInstances(input *ec2.RunInstancesInput) (*ec2.Reservation, error)
 	TerminateInstances(input *ec2.TerminateInstancesInput) (*ec2.TerminateInstancesOutput, error)
 	DeleteSecurityGroup(input *ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error)
+	RequestSpotInstances(input *ec2.RequestSpotInstancesInput) (*ec2.RequestSpotInstancesOutput, error)
+	WaitUntilSpotInstanceRequestFulfilled(*ec2.DescribeSpotInstanceRequestsInput) error
+
 }
 
 type EC2Helper struct {

--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -137,7 +137,7 @@ func AskSpotInstancePrice(h *ec2helper.EC2Helper) (string){
 }
 
 func AskPurchaseInstanceType() (string){
-	types := []config.Ec2PurchseInstanceType{config.OnDemand, config.SpotInstance, }
+	types := []config.EC2PurchseInstanceType{config.OnDemand, config.SpotInstance, }
 
 	data := [][]string{}
 	indexedOptions := []string{}
@@ -961,13 +961,13 @@ func AskConfirmationWithInput(simpleConfig *config.SimpleInfo, detailedConfig *c
 			vpcInfo = fmt.Sprintf("%s(%s)", *vpcTagName, *vpc.VpcId)
 		}
 	}
-	if simpleConfig.Ec2PurchaseInstanceType == "" {
-		simpleConfig.Ec2PurchaseInstanceType = config.OnDemand
+	if simpleConfig.EC2PurchaseInstanceType == "" {
+		simpleConfig.EC2PurchaseInstanceType = config.OnDemand
 	}
 
-	data := [][]string{{cli.Ec2PurchanceInstanceType, string(simpleConfig.Ec2PurchaseInstanceType)},}
+	data := [][]string{{cli.Ec2PurchanceInstanceType, string(simpleConfig.EC2PurchaseInstanceType)},}
 
-	if simpleConfig.Ec2PurchaseInstanceType == config.SpotInstance{
+	if simpleConfig.EC2PurchaseInstanceType == config.SpotInstance{
 		data = append(data, []string{cli.SpotInstancePrice, fmt.Sprint(simpleConfig.SpotInstancePrice)})
 	}
 

--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -961,6 +961,9 @@ func AskConfirmationWithInput(simpleConfig *config.SimpleInfo, detailedConfig *c
 			vpcInfo = fmt.Sprintf("%s(%s)", *vpcTagName, *vpc.VpcId)
 		}
 	}
+	if simpleConfig.Ec2PurchaseInstanceType == "" {
+		simpleConfig.Ec2PurchaseInstanceType = config.OnDemand
+	}
 
 	data := [][]string{{cli.Ec2PurchanceInstanceType, string(simpleConfig.Ec2PurchaseInstanceType)},}
 

--- a/pkg/question/question_test.go
+++ b/pkg/question/question_test.go
@@ -132,6 +132,19 @@ func TestAskQuestion_FunctionCheckedInput(t *testing.T) {
 	cleanupQuestionTest()
 }
 
+func TestAskQuestion_FunctionCheckSpotPrice(t *testing.T){
+	const expectedSpotInstancePrice = "0.003"
+	input.EC2Helper = testEC2
+	input.Fns = []question.CheckInput{
+		ec2helper.ValidateSpotInstancePrice,
+	}
+	initQuestionTest(t, "Spot Instance"+"\n")
+	answer := question.AskQuestion(input)
+	th.Equals(t, expectedSpotInstancePrice, answer)
+
+	cleanupQuestionTest()
+}
+
 /*
 Other Question Asking Tests
 */
@@ -337,6 +350,17 @@ func TestAskInstanceTypeMemory(t *testing.T) {
 
 	answer := question.AskInstanceTypeMemory()
 	th.Equals(t, expectedMemory, answer)
+
+	cleanupQuestionTest()
+}
+
+func TestAskWorkloadType(t *testing.T){
+	const expectedWorkload = config.SpotInstance
+
+	initQuestionTest(t, "2\n")
+
+	answer := question.AskPurchaseInstanceType()
+	th.Equals(t, expectedWorkload, answer)
 
 	cleanupQuestionTest()
 }

--- a/test/testhelper/ec2helper_mock.go
+++ b/test/testhelper/ec2helper_mock.go
@@ -36,6 +36,7 @@ type MockedEC2Svc struct {
 	DescribeInstancesPagesError              error
 	CreateTagsError                          error
 	RunInstancesError                        error
+	SpotInstanceRequestError                 error
 	TerminateInstancesError                  error
 	Regions                                  []*ec2.Region
 	AvailabilityZones                        []*ec2.AvailabilityZone
@@ -378,3 +379,20 @@ func findFilter(filters []*ec2.Filter, name string) []*string {
 func (e *MockedEC2Svc) DeleteSecurityGroup(input *ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
 	return nil, nil
 }
+
+
+func (e *MockedEC2Svc) RequestSpotInstances(input *ec2.RequestSpotInstancesInput) (*ec2.RequestSpotInstancesOutput, error){
+	output := &ec2.RequestSpotInstancesOutput{
+		SpotInstanceRequests: []*ec2.SpotInstanceRequest{
+			{
+				InstanceId: aws.String("i-12345"),
+			},
+		},
+	}
+	return output, e.SpotInstanceRequestError
+}
+
+func (e *MockedEC2Svc) 	WaitUntilSpotInstanceRequestFulfilled(*ec2.DescribeSpotInstanceRequestsInput) error{
+	return nil
+}
+


### PR DESCRIPTION
Issue #, if available:
https://github.com/awslabs/aws-simple-ec2-cli/issues/55

Description of changes:
This PR includes the ability to request for Spot Instances. To accomplish this, I have introduced a new command line arg called "Ec2 Purchase Instance Type". This is an enum which supports one of these two choices "OnDemand" and "SpotInstance". If "SpotInstance" is chosen as the EC2 Purchase instance type, only then it would prompt the user for Spot Price. Depending on the spot price provided by the user, the Spot Instance Requests may or may not succeed. By default OnDemand instances will be chosen unless otherwise specified.

We are running out of flags, I have chosen "z" as the short flag name to specify Ec2 Purchase Instance Type and "x" as the short flag name for specifying Spot Instance Price. Am happy to change them if needed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
