### PR TITLE
Fix AMI ID to accept valid images

### DIFF
--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -381,7 +381,7 @@ func ReadInstanceType(h *ec2helper.EC2Helper, simpleConfig *config.SimpleInfo) b
 }
 
 /*
-Ask user input for an image id. The user can select from provided options orenter a valid image id.
+Ask user input for an image id. The user can select from provided options or enter a valid image id.
 Return true if the function is executed successfully, false otherwise
 */
 func ReadImageId(h *ec2helper.EC2Helper, simpleConfig *config.SimpleInfo) bool {

--- a/pkg/cfn/cfn.go
+++ b/pkg/cfn/cfn.go
@@ -46,7 +46,7 @@ func New(sess *session.Session) *Cfn {
 	}
 }
 
-// Create a stack and ger resources in it, including VPC ID, subnet ID and instance ID
+// Create a stack and get resources in it, including VPC ID, subnet ID and instance ID
 func (c Cfn) CreateStackAndGetResources(availabilityZones []*ec2.AvailabilityZone,
 	stackName *string, template string) (vpcId *string, subnetIds []string, instanceId *string,
 	stackResources []*cloudformation.StackResource, err error) {

--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -495,13 +495,11 @@ func AskImage(h *ec2helper.EC2Helper, instanceType string) (*ec2.Image, error) {
 		Fns:               []CheckInput{ec2helper.ValidateImageId},
 	})
 
-	// Find the image information
-	if defaultImages != nil {
-		for _, image := range *defaultImages {
-			if *image.ImageId == answer {
-				return image, nil
-			}
-		}
+	//Find the image information
+	image, _ := h.GetImageById(answer)
+
+	if image != nil {
+		return image, nil
 	}
 
 	return nil, errors.New(fmt.Sprintf("No image information for %s found", answer))

--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -481,7 +481,7 @@ func AskImage(h *ec2helper.EC2Helper, instanceType string) (*ec2.Image, error) {
 	}
 
 	// Add the option to enter an image id
-	optionsText += "[ any image id ]: Select the image id\n"
+	optionsText += "[ any image id ]: Select the image id or provide your own image id\n"
 
 	question := "AMI"
 
@@ -496,13 +496,13 @@ func AskImage(h *ec2helper.EC2Helper, instanceType string) (*ec2.Image, error) {
 	})
 
 	//Find the image information
-	image, _ := h.GetImageById(answer)
+	image, err := h.GetImageById(answer)
 
-	if image != nil {
-		return image, nil
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("No image information for %s found", answer))
 	}
 
-	return nil, errors.New(fmt.Sprintf("No image information for %s found", answer))
+	return image, nil
 }
 
 // Ask if the users want to keep EBS volumes after instance termination


### PR DESCRIPTION
Issue #, if available: [51](https://github.com/awslabs/aws-simple-ec2-cli/issues/51)

Description of changes: 
- By passing a valid AMI ID through flags, we can launch an EC2 instance.
- Currently, in the interactive terminal, we can launch an instance if we select the images from the list of default images being generated based on region, instance type, etc.
- Modified "question.go" file to stop interactive terminal being terminated if user enters a valid AMI ID.
- Now user can enter a valid AMI ID that is different from the list of default images.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
