### PR TITLE
Validation fix if user enters invalid input

### DIFF
--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -60,13 +60,7 @@ func AskQuestion(input *AskQuestionInput) string {
 		fmt.Print(*input.OptionsString)
 	}
 
-	if input.DefaultOptionRepr != nil {
-		fmt.Printf("%s [%s]:  ", input.QuestionString, *input.DefaultOptionRepr)
-	} else if input.DefaultOption != nil {
-		fmt.Printf("%s [%s]:  ", input.QuestionString, *input.DefaultOption)
-	} else {
-		fmt.Printf(input.QuestionString + ": ")
-	}
+	GetQuestion(input)
 
 	// Keep asking for user input until one valid input in entered
 	for {
@@ -121,13 +115,18 @@ func AskQuestion(input *AskQuestionInput) string {
 
 		// No match at all
 		fmt.Println("Input invalid. Please try again.")
-		if input.DefaultOptionRepr != nil {
-			fmt.Printf("%s [%s]:  ", input.QuestionString, *input.DefaultOptionRepr)
-		} else if input.DefaultOption != nil {
-			fmt.Printf("%s [%s]:  ", input.QuestionString, *input.DefaultOption)
-		} else {
-			fmt.Printf(input.QuestionString + ": ")
-		}
+		GetQuestion(input)
+	}
+}
+
+// Displays question with default values
+func GetQuestion(input *AskQuestionInput) {
+	if input.DefaultOptionRepr != nil {
+		fmt.Printf("%s [%s]:  ", input.QuestionString, *input.DefaultOptionRepr)
+	} else if input.DefaultOption != nil {
+		fmt.Printf("%s [%s]:  ", input.QuestionString, *input.DefaultOption)
+	} else {
+		fmt.Printf(input.QuestionString + ": ")
 	}
 }
 

--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -60,10 +60,11 @@ func AskQuestion(input *AskQuestionInput) string {
 		fmt.Print(*input.OptionsString)
 	}
 
-	GetQuestion(input)
-
 	// Keep asking for user input until one valid input in entered
 	for {
+		// GetQuestion displays question with default values
+		GetQuestion(input)
+
 		// Read input from the user and convert CRLF to LF
 		reader := bufio.NewReader(os.Stdin)
 		answer, _ := reader.ReadString('\n')
@@ -115,11 +116,10 @@ func AskQuestion(input *AskQuestionInput) string {
 
 		// No match at all
 		fmt.Println("Input invalid. Please try again.")
-		GetQuestion(input)
 	}
 }
 
-// Displays question with default values
+// GetQuestion displays question with default values
 func GetQuestion(input *AskQuestionInput) {
 	if input.DefaultOptionRepr != nil {
 		fmt.Printf("%s [%s]:  ", input.QuestionString, *input.DefaultOptionRepr)

--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -121,6 +121,13 @@ func AskQuestion(input *AskQuestionInput) string {
 
 		// No match at all
 		fmt.Println("Input invalid. Please try again.")
+		if input.DefaultOptionRepr != nil {
+			fmt.Printf("%s [%s]:  ", input.QuestionString, *input.DefaultOptionRepr)
+		} else if input.DefaultOption != nil {
+			fmt.Printf("%s [%s]:  ", input.QuestionString, *input.DefaultOption)
+		} else {
+			fmt.Printf(input.QuestionString + ": ")
+		}
 	}
 }
 

--- a/pkg/question/question_test.go
+++ b/pkg/question/question_test.go
@@ -47,6 +47,9 @@ AskQuestion Tests
 
 const expectedOutput = `
 These are the optionsThis is a question [default option]:  `
+const invalidInputQuestionPrompt = `
+These are the optionsThis is a question [default option]:  Input invalid. Please try again.
+This is a question [default option]:  `
 
 var input = &question.AskQuestionInput{
 	QuestionString:    "This is a question",
@@ -67,6 +70,17 @@ func TestAskQuestion_StringOptionAnswer(t *testing.T) {
 	output := cleanupQuestionTest()
 	th.Equals(t, expectedOutput, output)
 	th.Equals(t, testResponse, answer)
+}
+
+func TestAskQuestion_InvalidInput(t *testing.T) {
+	const expectedInvalidInput = "heap"
+	initQuestionTest(t, expectedInvalidInput+"\n")
+	input.AcceptAnyString = false
+
+	question.AskQuestion(input)
+
+	output := cleanupQuestionTest()
+	th.Equals(t, invalidInputQuestionPrompt, output)
 }
 
 func TestAskQuestion_IndexedOptionAnswer(t *testing.T) {


### PR DESCRIPTION
Issue #, if [available:] https://github.com/awslabs/aws-simple-ec2-cli/issues/70

Description of changes:
* Made few changes in the 'question.go' file to avoid proceeding with default values when user enters an invalid input.
* Initially in the interactive terminal, if user enters an invalid input they will get a message "Invalid input. Please try again" and if user hits enter twice at this point default values are considered, they can proceed further and user will get to know that default values are selected only when they reach the last step.
* Added few validations to re-prompt the question whenever user enters invalid inputs, they can either enter a valid input or proceed with default values.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
