### PR TITLE
Changed year default format for tag value message

### DIFF
--- a/pkg/tag/tag.go
+++ b/pkg/tag/tag.go
@@ -25,7 +25,7 @@ import (
 func GetSimpleEc2Tags() *map[string]string {
 	now := time.Now()
 	zone, _ := now.Zone()
-	nowString := fmt.Sprintf("%02d-%02d-%02d %02d:%02d:%02d %s", now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(),
+	nowString := fmt.Sprintf("%04d-%02d-%02d %02d:%02d:%02d %s", now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(),
 		now.Second(), zone)
 
 	tags := map[string]string{


### PR DESCRIPTION
Issue #, if available: #63

Description of changes:
Previously changed the format of the date in the tag-value message to be prefaced by a zero if only 1 digit, such as 01, 02, 03, etc.
Changed the format of the year in the tag-value message from 2 digits to 4 digits.

Before: 2022-6-1 14:14:26 CDT
After: 2022-06-01 14:35:37 CDT 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
