### PR TITLE
Fix most of the unit tests

### DIFF
--- a/pkg/cfn/template_test.go
+++ b/pkg/cfn/template_test.go
@@ -24,6 +24,8 @@ import (
 var backupSimpleEc2String = cfn.SimpleEc2CloudformationTemplateEncoded
 
 func TestDecodeTemplateVariables_Success(t *testing.T) {
+	// Note that this test will fail when run through VSCode because it relies on some variable substitution
+	// done by the way the makefile invokes `go test`. It should pass via `make unit-test`.
 	err := cfn.DecodeTemplateVariables()
 	th.Ok(t, err)
 }

--- a/pkg/ec2helper/ec2helper_test.go
+++ b/pkg/ec2helper/ec2helper_test.go
@@ -42,6 +42,8 @@ Region Tests
 
 const testRegion = "Test Region"
 
+var defaultArchitecture = aws.StringSlice([]string{"x86_64"})
+
 func TestChangeRegion(t *testing.T) {
 	testEC2.Sess = session.Must(session.NewSession())
 	testEC2.ChangeRegion(testRegion)
@@ -460,13 +462,13 @@ func TestGetLatestImages_Success_Ebs(t *testing.T) {
 		Images: testImages,
 	}
 
-	actualImages, err := testEC2.GetLatestImages(nil, aws.StringSlice([]string{"x86_64"}))
+	actualImages, err := testEC2.GetLatestImages(nil, defaultArchitecture)
 	th.Ok(t, err)
 	th.Equals(t, testMapEbs, *actualImages)
 }
 
 func TestGetLatestImages_Success_InstanceStore(t *testing.T) {
-	actualImages, err := testEC2.GetLatestImages(aws.String("instance-store"), aws.StringSlice([]string{"x86_64"}))
+	actualImages, err := testEC2.GetLatestImages(aws.String("instance-store"), defaultArchitecture)
 	th.Ok(t, err)
 	th.Equals(t, testMapInstanceStore, *actualImages)
 }
@@ -476,7 +478,7 @@ func TestGetLatestImages_NoResult(t *testing.T) {
 		Images: []*ec2.Image{},
 	}
 
-	_, err := testEC2.GetLatestImages(nil, aws.StringSlice([]string{"x86_64"}))
+	_, err := testEC2.GetLatestImages(nil, defaultArchitecture)
 	th.Ok(t, err)
 }
 
@@ -485,7 +487,7 @@ func TestGetLatestImages_DescribeImagesError(t *testing.T) {
 		DescribeImagesError: errors.New("Test error"),
 	}
 
-	_, err := testEC2.GetLatestImages(nil, aws.StringSlice([]string{"x86_64"}))
+	_, err := testEC2.GetLatestImages(nil, defaultArchitecture)
 	th.Nok(t, err)
 }
 
@@ -494,7 +496,7 @@ func TestGetDefaultImage_Success(t *testing.T) {
 		Images: testImages,
 	}
 
-	actualImage, err := testEC2.GetDefaultImage(nil, aws.StringSlice([]string{"x86_64"}))
+	actualImage, err := testEC2.GetDefaultImage(nil, defaultArchitecture)
 	th.Ok(t, err)
 	th.Equals(t, *lastImage.ImageId, *actualImage.ImageId)
 }
@@ -504,7 +506,7 @@ func TestGetDefaultImage_NoResult(t *testing.T) {
 		Images: []*ec2.Image{},
 	}
 
-	_, err := testEC2.GetDefaultImage(nil, aws.StringSlice([]string{"x86_64"}))
+	_, err := testEC2.GetDefaultImage(nil, defaultArchitecture)
 	th.Nok(t, err)
 }
 
@@ -513,7 +515,7 @@ func TestGetDefaultImage_DescribeImagesError(t *testing.T) {
 		DescribeImagesError: errors.New("Test error"),
 	}
 
-	_, err := testEC2.GetDefaultImage(nil, aws.StringSlice([]string{"x86_64"}))
+	_, err := testEC2.GetDefaultImage(nil, defaultArchitecture)
 	th.Nok(t, err)
 }
 
@@ -1023,6 +1025,7 @@ var defaultConfigSvc = &th.MockedEC2Svc{
 			InstanceType:             aws.String(testInstanceType),
 			FreeTierEligible:         aws.Bool(true),
 			InstanceStorageSupported: aws.Bool(true),
+			ProcessorInfo:            &ec2.ProcessorInfo{SupportedArchitectures: defaultArchitecture},
 		},
 	},
 	Images: []*ec2.Image{
@@ -1054,6 +1057,7 @@ var defaultConfigSvc = &th.MockedEC2Svc{
 
 func TestGetDefaultSimpleConfig_Success(t *testing.T) {
 	testEC2.Svc = defaultConfigSvc
+	testEC2.Sess = session.Must(session.NewSession())
 
 	actualSimpleConfig, err := testEC2.GetDefaultSimpleConfig()
 	th.Ok(t, err)

--- a/pkg/question/question_test.go
+++ b/pkg/question/question_test.go
@@ -40,6 +40,7 @@ var testEC2 = &ec2helper.EC2Helper{
 		},
 	},
 }
+var defaultArchitecture = aws.StringSlice([]string{"x86_64"})
 
 /*
 AskQuestion Tests
@@ -366,6 +367,7 @@ func TestAskImage_Success(t *testing.T) {
 			{
 				InstanceType:             aws.String(testInstanceType),
 				InstanceStorageSupported: aws.Bool(true),
+				ProcessorInfo:            &ec2.ProcessorInfo{SupportedArchitectures: defaultArchitecture},
 			},
 		},
 		Images: []*ec2.Image{
@@ -392,6 +394,7 @@ func TestAskImage_NoImage(t *testing.T) {
 			{
 				InstanceType:             aws.String(testInstanceType),
 				InstanceStorageSupported: aws.Bool(true),
+				ProcessorInfo:            &ec2.ProcessorInfo{SupportedArchitectures: defaultArchitecture},
 			},
 		},
 	}
@@ -425,6 +428,7 @@ func TestAskImage_DescribeImagesError(t *testing.T) {
 			{
 				InstanceType:             aws.String(testInstanceType),
 				InstanceStorageSupported: aws.Bool(true),
+				ProcessorInfo:            &ec2.ProcessorInfo{SupportedArchitectures: defaultArchitecture},
 			},
 		},
 		DescribeImagesError: errors.New("Test error"),

--- a/pkg/table/table_test.go
+++ b/pkg/table/table_test.go
@@ -32,9 +32,7 @@ func TestBuildTable(t *testing.T) {
 | ROW NUM | ELEMENTS 1 | ELEMENTS 2 |
 +---------+------------+------------+
 | Row 1   | Element 1  | Element 2  |
-+---------+------------+------------+
 | Row 2   | Element 3  | Element 4  |
-+---------+------------+------------+
 | Row 3   | Element 5  | Element 6  |
 +---------+------------+------------+
 `

--- a/pkg/tag/tag_test.go
+++ b/pkg/tag/tag_test.go
@@ -56,7 +56,7 @@ func TestGetTagAsFilter(t *testing.T) {
 	actualTagFilter, err := tag.GetTagAsFilter(*tags)
 	now := time.Now()
 	zone, _ := now.Zone()
-	currTimeStr := fmt.Sprintf("%d-%d-%d %d:%d:%d %s", now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(),
+	currTimeStr := fmt.Sprintf("%04d-%02d-%02d %02d:%02d:%02d %s", now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(),
 		now.Second(), zone)
 	// assign current time to avoid manually traversing map and checking time format
 	expectedTagAsFilter[1].Values = aws.StringSlice([]string{currTimeStr})


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**

After several recent changes, the unit tests broke, but since we don't run them automatically on PRs via GitHub Actions, it took a while for us to notice. I intend to get the tests running on PRs in the future, but getting them passing again locally is the first step.

Here are the tests I fixed (they're each broken into a separate commit if you want to review individually):

* Fix unit test after table formatting change in https://github.com/awslabs/aws-simple-ec2-cli/pull/61
* Add note about running CFN tests from VSCode (one of them only passes if you invoke via the makefile)
* Fix unit test for tag date/time formatting change in https://github.com/awslabs/aws-simple-ec2-cli/pull/73
* Fix unit tests that rely on image API call, after change in https://github.com/awslabs/aws-simple-ec2-cli/pull/60

The only one unit test that isn't passing after this is `TestAskQuestion_AnyStringAnswer()`, even though it seems correct.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
