### PR TITLE
Ensure the GHA build fails if a unit test fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,8 @@ build-docker-images:
 	${MAKEFILE_PATH}/scripts/build-docker-images -p ${SUPPORTED_PLATFORMS} -r ${IMG} -v ${VERSION}
 
 unit-test:
-	${GO_TEST}/pkg/... -v -coverprofile=coverage.out -covermode=atomic -outputdir=${BUILD_DIR_PATH}; go tool cover -func ${BUILD_DIR_PATH}/coverage.out
+	${GO_TEST}/pkg/... -v -coverprofile=coverage.out -covermode=atomic -outputdir=${BUILD_DIR_PATH}
+	go tool cover -func ${BUILD_DIR_PATH}/coverage.out
 
 e2e-test:
 	${GO_TEST}/test/e2e/... -v

--- a/pkg/question/question_test.go
+++ b/pkg/question/question_test.go
@@ -115,8 +115,10 @@ func TestAskQuestion_IntegerAnswer(t *testing.T) {
 }
 
 func TestAskQuestion_AnyStringAnswer(t *testing.T) {
+	// This test needs its own copy of the AskQuestionInput object to prevent some kind of race condition with the other
+	// tests when running the whole test suite. We don't exactly know why, but it works.
 	var anyStringQuestion = &question.AskQuestionInput{
-		QuestionString:  "This is a question",
+		QuestionString:  "This is a question?",
 		AcceptAnyString: true,
 	}
 	const expectedString = "any string"

--- a/pkg/question/question_test.go
+++ b/pkg/question/question_test.go
@@ -115,10 +115,14 @@ func TestAskQuestion_IntegerAnswer(t *testing.T) {
 }
 
 func TestAskQuestion_AnyStringAnswer(t *testing.T) {
+	var anyStringQuestion = &question.AskQuestionInput{
+		QuestionString:  "This is a question",
+		AcceptAnyString: true,
+	}
 	const expectedString = "any string"
 	initQuestionTest(t, expectedString+"\n")
 
-	answer := question.AskQuestion(input)
+	answer := question.AskQuestion(anyStringQuestion)
 	th.Equals(t, expectedString, answer)
 
 	cleanupQuestionTest()

--- a/pkg/tag/tag_test.go
+++ b/pkg/tag/tag_test.go
@@ -37,7 +37,7 @@ var expectedTagAsFilter = []*ec2.Filter{
 	},
 }
 
-const createTimeRegex = "^[0-9]{4}-[0-9]{1,2}-[0-9]{1,2} [0-9]{1,2}:[0-9]{1,2}:[0-9]{1,2} [A-Z]{3}"
+const createTimeRegex = "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [A-Z]{3}"
 
 func TestGetTags(t *testing.T) {
 	tags := tag.GetSimpleEc2Tags()
@@ -63,5 +63,15 @@ func TestGetTagAsFilter(t *testing.T) {
 
 	th.Ok(t, err)
 	th.Assert(t, len(actualTagFilter) == 2, "TagFilters length should be 2")
-	th.Equals(t, expectedTagAsFilter, actualTagFilter)
+	for _, expectedTag := range expectedTagAsFilter {
+		thisTagMatches := false
+		for _, actualTag := range actualTagFilter {
+			if *expectedTag.Name == *actualTag.Name {
+				th.Equals(t, expectedTag, actualTag)
+				thisTagMatches = true
+				break
+			}
+		}
+		th.Assert(t, thisTagMatches, fmt.Sprintf("Unable to find matching actual tag filter for expected tag filter %s", *expectedTag.Name))
+	}
 }


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:

1. Update two fickle unit tests to make them more robust
2. Remove semicolon in makefile that suppressed any non-success status codes from the unit test run

If you want to see some builds that failed because of failing unit tests, see [here](https://github.com/snay2/aws-simple-ec2-cli/actions/runs/2504495404) and [here](https://github.com/snay2/aws-simple-ec2-cli/actions/runs/2512026346).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
