### PR TITLE
Unique SSH security groups

### DIFF
--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -511,8 +511,8 @@ func ReadSecurityGroups(h *ec2helper.EC2Helper, simpleConfig *config.SimpleInfo,
 	retrievedGroups, err := h.GetSecurityGroupsByVpc(vpcId)
 	cli.ShowError(err, "Getting security groups in VPC failed")
 
-	// Keep asking for security groups
-	for {
+	// Keep asking for security groups while there are less than 5 security groups
+	for len(groups) < 5 {
 		securityGroupAnswer := question.AskSecurityGroups(retrievedGroups, groups)
 
 		// End questions if the user selects "no"
@@ -532,21 +532,6 @@ func ReadSecurityGroups(h *ec2helper.EC2Helper, simpleConfig *config.SimpleInfo,
 			cli.ShowError(err, "Getting security gtoups in VPC failed")
 
 			continue
-		}
-
-		// Add all security groups available if the user selects "all"
-		if securityGroupAnswer == cli.ResponseAll {
-			allSecurityGroups, err := h.GetSecurityGroupsByVpc(vpcId)
-			if cli.ShowError(err, "Getting security groups in VPC failed") {
-				return false
-			}
-
-			groups = []string{}
-			for _, group := range allSecurityGroups {
-				groups = append(groups, *group.GroupId)
-			}
-
-			break
 		}
 
 		// Simply add the selected security group in this case

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -534,6 +534,21 @@ func ReadSecurityGroups(h *ec2helper.EC2Helper, simpleConfig *config.SimpleInfo,
 			continue
 		}
 
+		// Add all security groups available if the user selects "all"
+		if securityGroupAnswer == cli.ResponseAll {
+			allSecurityGroups, err := h.GetSecurityGroupsByVpc(vpcId)
+			if cli.ShowError(err, "Getting security groups in VPC failed") {
+				return false
+			}
+
+			groups = []string{}
+			for _, group := range allSecurityGroups {
+				groups = append(groups, *group.GroupId)
+			}
+
+			break
+		}
+
 		// Simply add the selected security group in this case
 		groups = append(groups, securityGroupAnswer)
 	}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
+	github.com/google/uuid v1.3.0
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=

--- a/pkg/ec2helper/ec2helper.go
+++ b/pkg/ec2helper/ec2helper.go
@@ -755,10 +755,11 @@ func (h *EC2Helper) GetSecurityGroupsByVpc(vpcId string) ([]*ec2.SecurityGroup, 
 func (h *EC2Helper) CreateSecurityGroupForSsh(vpcId string) (*string, error) {
 	fmt.Println("Creating new security group...")
 
+	groupNameUuid := uuid.New()
 	// Create a new security group
 	creationInput := &ec2.CreateSecurityGroupInput{
 		Description: aws.String("Created by simple-ec2 for SSH connection to instances"),
-		GroupName:   aws.String("simple-ec2 SSH"),
+		GroupName:   aws.String(fmt.Sprintf("simple-ec2 SSH-%s", groupNameUuid)),
 		VpcId:       aws.String(vpcId),
 	}
 

--- a/pkg/ec2helper/ec2helper.go
+++ b/pkg/ec2helper/ec2helper.go
@@ -33,6 +33,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/google/uuid"
 )
 
 const DefaultRegion = "us-east-2"

--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -776,6 +776,13 @@ func AskSecurityGroups(groups []*ec2.SecurityGroup, addedGroups []string) string
 		return cli.ResponseNo
 	}
 
+	// Add "add all" option
+	if len(groups) <= 5 {
+		indexedOptions = append(indexedOptions, cli.ResponseAll)
+		data = append(data, []string{fmt.Sprintf("%d.", len(data)+1),
+			"Add all available security groups"})
+	}
+
 	// Add "new" option
 	indexedOptions = append(indexedOptions, cli.ResponseNew)
 	data = append(data, []string{fmt.Sprintf("%d.", len(data)+1),

--- a/pkg/question/question.go
+++ b/pkg/question/question.go
@@ -776,11 +776,6 @@ func AskSecurityGroups(groups []*ec2.SecurityGroup, addedGroups []string) string
 		return cli.ResponseNo
 	}
 
-	// Add "add all" option
-	indexedOptions = append(indexedOptions, cli.ResponseAll)
-	data = append(data, []string{fmt.Sprintf("%d.", len(data)+1),
-		"Add all available security groups"})
-
 	// Add "new" option
 	indexedOptions = append(indexedOptions, cli.ResponseNew)
 	data = append(data, []string{fmt.Sprintf("%d.", len(data)+1),
@@ -788,7 +783,7 @@ func AskSecurityGroups(groups []*ec2.SecurityGroup, addedGroups []string) string
 
 	// Add "done" option, if the added security group slice is not empty
 	if len(addedGroups) > 0 {
-		question = fmt.Sprintf("If you wish to add additional security group(s), add from the following:\nSecurity Group(s) already selected: %s", addedGroups)
+		question = fmt.Sprintf("Up to 5 security groups may be added. If you wish to add additional security group(s), add from the following:\nSecurity Group(s) already selected: %s", addedGroups)
 		indexedOptions = append(indexedOptions, cli.ResponseNo)
 		data = append(data, []string{fmt.Sprintf("%d.", len(data)+1),
 			"Don't add any more security group"})


### PR DESCRIPTION
Issue #, if available: #78 

Description of changes: Fixed bug where SSH security group used static group name, causing errors when creating multiple ssh security groups. Set limit of 5 on how many security groups can be added to a VPC in order to avoid an error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Security Group Name Before: simple-ec2 SSH
Security Group Name After: simple-ec2 SSH-d5d9c678-7afb-4fb8-b734-d8bef1c4216d