### PR TITLE
Fix Homebrew sync script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ CLI_BINARY_NAME = simple-ec2
 VERSION ?= $(shell git describe --tags --always --dirty)
 IMG ?= amazon/aws-simple-ec2-cli
 BIN ?= simple-ec2
-REPO_FULL_NAME ?= awslabs/aws-simple-ec2-cli
+REPO_SHORT_NAME ?= aws-simple-ec2-cli
+REPO_FULL_NAME ?= awslabs/${REPO_SHORT_NAME}
 GOOS ?= $(uname | tr '[:upper:]' '[:lower:]')
 GOARCH ?= amd64
 GOPROXY ?= "https://proxy.golang.org,direct"
@@ -114,10 +115,10 @@ fmt:
 	goimports -w ./ && gofmt -s -w ./
 
 homebrew-sync-dry-run:
-	${MAKEFILE_PATH}/scripts/sync-to-aws-homebrew-tap -d -b ${BIN} -r ${REPO_FULL_NAME} -p ${SUPPORTED_PLATFORMS} -v ${LATEST_RELEASE_TAG}
+	${MAKEFILE_PATH}/scripts/sync-to-aws-homebrew-tap -d -b ${BIN} -f ${REPO_SHORT_NAME} -r ${REPO_FULL_NAME} -p ${SUPPORTED_PLATFORMS} -v ${LATEST_RELEASE_TAG}
 
 homebrew-sync:
-	${MAKEFILE_PATH}/scripts/sync-to-aws-homebrew-tap -b ${BIN} -r ${REPO_FULL_NAME} -p ${SUPPORTED_PLATFORMS}
+	${MAKEFILE_PATH}/scripts/sync-to-aws-homebrew-tap -b ${BIN} -f ${REPO_SHORT_NAME} -r ${REPO_FULL_NAME} -p ${SUPPORTED_PLATFORMS}
 
 ## requires a github token
 upload-resources-to-github:

--- a/scripts/sync-to-aws-homebrew-tap
+++ b/scripts/sync-to-aws-homebrew-tap
@@ -15,6 +15,7 @@ BREW_CONFIG_DIR="${BUILD_DIR}/brew-config"
 
 REPO=$(make -s -f "${SCRIPTPATH}/../Makefile" repo-full-name)
 BINARY_BASE=""
+FORMULA_NAME=""
 PLATFORMS=("darwin/amd64" "linux/amd64")
 DRY_RUN=0
 
@@ -41,18 +42,22 @@ USAGE=$(cat << EOM
             -r          Github repo to sync to in the form of "org/name"  (i.e. -r "awslabs/aws-simple-ec2-cli") [DEFAULT: output of \`make repo-full-name\`]
             -v          VERSION: The application version of the docker image [DEFAULT: output of \`make version\`]
             -p          Platform pair list (os/architecture) [DEFAULT: linux/amd64]
+            -f          Formula name [DEFAULT: same as binary basename]
             -d          Dry-Run will do all steps except pushing to git and opening the sync PR
 EOM
 )
 
 # Process our input arguments
-while getopts "p:b:r:v:d" opt; do
+while getopts "p:b:f:r:v:d" opt; do
   case ${opt} in
     r ) # Github repo
         REPO="$OPTARG"
       ;;
     b ) # binary basename
         BINARY_BASE="$OPTARG"
+      ;;
+    f ) # Formula name
+        FORMULA_NAME="$OPTARG"
       ;;
     p ) # Supported Platforms
         IFS=',' read -ra PLATFORMS <<< "$OPTARG"
@@ -82,6 +87,10 @@ fi
 
 if [[ -z "${REPO}" ]]; then 
   echo "Repo (-r) must be specified if no \"make repo-full-name\" target exists"
+fi
+
+if [[ -z "${FORMULA_NAME}" ]]; then
+  FORMULA_NAME=${BINARY_BASE}
 fi
 
 if [[ -z $(command -v gh) ]] || [[ ! $(gh --version) =~ $GH_CLI_VERSION ]]; then
@@ -170,7 +179,7 @@ for os_arch in "${PLATFORMS[@]}"; do
 
 done
 
-cat << EOM > "${BREW_CONFIG_DIR}/${BINARY_BASE}.json"
+cat << EOM > "${BREW_CONFIG_DIR}/${FORMULA_NAME}.json"
 {
     "name": "${BINARY_BASE}",
     "version": "${VERSION_NUM}",
@@ -178,6 +187,7 @@ cat << EOM > "${BREW_CONFIG_DIR}/${BINARY_BASE}.json"
     "bottle": {
         "root_url": "${BASE_ASSET_URL}",
         "sha256": {
+            "arm64_big_sur": "",
             "sierra": "${MAC_HASH}",
             "linux": "${LINUX_HASH}",
             "linux_arm": "${LINUX_ARM64_HASH}"


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**

The automated process that opens a PR to https://github.com/aws/homebrew-tap is using the wrong file name (`simple-ec2.json` instead of `aws-simple-ec2-cli.json`), meaning the diff is always wrong and we have to manually open a release PR there with the changes. Here's an example of the most recent incorrect PR: https://github.com/aws/homebrew-tap/pull/360

This repo uses different names for the binary and for the brew formula, unlike our other repos. Introduced a new optional parameter to the homebrew sync script to allow specifying a formula name. If not supplied, it will default to the binary name, keeping the same behavior as before.

Some work remains to get this on par with instance-selector (such as adding support for Mac M1 builds).

**Testing:**

I used this code in a dry-run configuration to generate the diff for https://github.com/aws/homebrew-tap/pull/361, which verified that it works as intended. Next time we release simple-ec2, the GitHub Actions should be able to automatically open the homebrew-tap release PR correctly.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.*
