### PR TITLE
Set tags on instance when using a new Launch Template

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -74,6 +74,7 @@ type RequestInstanceInfo struct {
 	LaunchTemplateBlockMappings       []*ec2.LaunchTemplateBlockDeviceMappingRequest
 	InstanceInitiatedShutdownBehavior *string
 	UserData                          *string
+	LaunchTemplateTagSpecs            []*ec2.LaunchTemplateTagSpecificationRequest
 }
 
 func NewSimpleInfo() *SimpleInfo {

--- a/pkg/ec2helper/ec2helper.go
+++ b/pkg/ec2helper/ec2helper.go
@@ -1329,6 +1329,7 @@ func (h *EC2Helper) CreateLaunchTemplate(simpleConfig *config.SimpleInfo, detail
 			BlockDeviceMappings:               dataConfig.LaunchTemplateBlockMappings,
 			InstanceInitiatedShutdownBehavior: dataConfig.InstanceInitiatedShutdownBehavior,
 			UserData:                          dataConfig.UserData,
+			TagSpecifications:                 dataConfig.LaunchTemplateTagSpecs,
 		},
 		LaunchTemplateName: aws.String(fmt.Sprintf("SimpleEC2LaunchTemplate-%s", launchIdentifier)),
 		VersionDescription: aws.String(fmt.Sprintf("Launch Template %s", launchIdentifier)),
@@ -1363,6 +1364,16 @@ func createRequestInstanceConfig(simpleConfig *config.SimpleInfo, detailedConfig
 	if simpleConfig.IamInstanceProfile != "" {
 		requestInstanceConfig.IamInstanceProfile = &ec2.IamInstanceProfileSpecification{
 			Name: aws.String(simpleConfig.IamInstanceProfile),
+		}
+	}
+	if detailedConfig.TagSpecs != nil {
+		requestInstanceConfig.LaunchTemplateTagSpecs = []*ec2.LaunchTemplateTagSpecificationRequest{}
+		for _, tagSpec := range detailedConfig.TagSpecs {
+			ltTagSpec := ec2.LaunchTemplateTagSpecificationRequest{
+				ResourceType: aws.String("instance"),
+				Tags:         tagSpec.Tags,
+			}
+			requestInstanceConfig.LaunchTemplateTagSpecs = append(requestInstanceConfig.LaunchTemplateTagSpecs, &ltTagSpec)
 		}
 	}
 


### PR DESCRIPTION
**Issue #, if available:** #87

**Description of changes:**

Our new code for launching Spot instances with CreateFleet requires using a Launch Template that we create on the fly. That Launch Template did not include a tag specification, so Spot instances created this way would not have the default Simple-EC2 tags (`CreatedBy` and `CreatedTime`) or any user-specified tags. This is a difference from launching On-Demand instances with RunInstances, where the tags are currently set correctly.

**Testing:**

Launched an On-Demand instance and a Spot instance with the new code and verified that they both got the Simple-EC2 tags and my own tags (item `1` below is the Spot instance):

```
+--------+---------------------+-------------------------------+--------------------------------------------+
| OPTION |      INSTANCE       |            TAG-KEY            |                 TAG-VALUE                  |
+--------+---------------------+-------------------------------+--------------------------------------------+
| 1.     | i-083557c9cd7317938 | CreatedTime                   | 2022-08-04 10:23:44 CDT                    |
|        |                     | myTag                         | myValue                                    |
|        |                     | CreatedBy                     | simple-ec2                                 |
|        |                     | otherTag                      | otherValue                                 |
|        |                     | aws:ec2launchtemplate:version | 1                                          |
|        |                     | aws:ec2:fleet-id              | fleet-bdac60ae-8b9f-693c-0c12-8c084246ae68 |
|        |                     | aws:ec2launchtemplate:id      | lt-02bf7c0436455725c                       |
| 2.     | i-0ab5a266a55f63fb4 | myTag                         | myValue                                    |
|        |                     | CreatedTime                   | 2022-08-04 10:22:13 CDT                    |
|        |                     | CreatedBy                     | simple-ec2                                 |
|        |                     | otherTag                      | otherValue                                 |
+--------+---------------------+-------------------------------+--------------------------------------------+
```

Note that the Spot instance also has some default tags related to Fleet and Launch Templates; we're leaving those intact.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
