### PR TITLE
Fix some filenames missed in previous fix for homebrew sync script

### DIFF
--- a/scripts/sync-to-aws-homebrew-tap
+++ b/scripts/sync-to-aws-homebrew-tap
@@ -217,9 +217,9 @@ if [[ "${DRY_RUN}" -eq 0 ]]; then
   FORK_RELEASE_BRANCH="${BINARY_BASE}-${VERSION}-${BUILD_ID}"
   git checkout -b "${FORK_RELEASE_BRANCH}" upstream/${DEFAULT_BRANCH}
 
-  cp "${BREW_CONFIG_DIR}/${BINARY_BASE}.json" "${FORK_DIR}/bottle-configs/${BINARY_BASE}.json"
+  cp "${BREW_CONFIG_DIR}/${FORMULA_NAME}.json" "${FORK_DIR}/bottle-configs/${FORMULA_NAME}.json"
   
-  git add "bottle-configs/${BINARY_BASE}.json"
+  git add "bottle-configs/${FORMULA_NAME}.json"
   git commit -m "${BINARY_BASE} update to version ${VERSION_NUM}"
 
   RELEASE_ID=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**

In #83, I made a first pass at fixing the homebrew sync script, which is part of the release process for this repo. However, in my manual testing I missed a few filename references in the script, meaning that the automated step that runs in GitHub Actions to actually open the PR to [aws/homebrew-tap](https://github.com/aws/homebrew-tap) failed ([see log here](https://github.com/awslabs/aws-simple-ec2-cli/runs/7860793186?check_suite_focus=true#step:4:136)).

This PR fixes all the rest of the filename references.

**Testing:**

Ran a full end-to-end `make homebrew-sync` from my local machine (required creating a [personal access token](https://github.com/settings/tokens) and setting it via `export GITHUB_TOKEN=<token>` and `export GITHUB_USERNAME=<username>`). That succeeded and resulted in https://github.com/aws/homebrew-tap/pull/372.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
