### PR TITLE
Other prep work for the Bubble Tea implementation

### DIFF
--- a/pkg/cfn/cfn.go
+++ b/pkg/cfn/cfn.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/google/uuid"
 )
 
 const DefaultStackName = "simple-ec2"
@@ -51,7 +52,8 @@ func (c Cfn) CreateStackAndGetResources(availabilityZones []*ec2.AvailabilityZon
 	stackName *string, template string) (vpcId *string, subnetIds []string, instanceId *string,
 	stackResources []*cloudformation.StackResource, err error) {
 	if stackName == nil {
-		stackName = aws.String(DefaultStackName)
+		stackIdentifier := uuid.New()
+		stackName = aws.String(fmt.Sprintf("%s%s", DefaultStackName, stackIdentifier))
 	}
 
 	zonesToUse := []*ec2.AvailabilityZone{}

--- a/pkg/cfn/cfn_test.go
+++ b/pkg/cfn/cfn_test.go
@@ -92,7 +92,7 @@ func TestCreateStackAndGetResources_Success(t *testing.T) {
 		StackEvents:    mockedEvents,
 	}
 
-	vpcId, subnetIds, instanceId, _, err := testCfn.CreateStackAndGetResources(testAzs, nil, "")
+	vpcId, subnetIds, instanceId, _, err := testCfn.CreateStackAndGetResources(testAzs, aws.String(cfn.DefaultStackName), "")
 	th.Ok(t, err)
 	th.Equals(t, testVpcId, *vpcId)
 	th.Equals(t, testSubnetIds, subnetIds)
@@ -106,7 +106,7 @@ func TestCreateStackAndGetResources_DescribeStackEventsPagesError(t *testing.T) 
 		DescribeStackEventsPagesError: errors.New("Test error"),
 	}
 
-	_, _, _, _, err := testCfn.CreateStackAndGetResources(testAzs, nil, "")
+	_, _, _, _, err := testCfn.CreateStackAndGetResources(testAzs, aws.String(cfn.DefaultStackName), "")
 	th.Nok(t, err)
 }
 
@@ -118,7 +118,7 @@ func TestCreateStackAndGetResources_DescribeStackResourcesError(t *testing.T) {
 		DescribeStackResourcesError: errors.New("Test error"),
 	}
 
-	_, _, _, _, err := testCfn.CreateStackAndGetResources(testAzs, nil, "")
+	_, _, _, _, err := testCfn.CreateStackAndGetResources(testAzs, aws.String(cfn.DefaultStackName), "")
 	th.Nok(t, err)
 }
 
@@ -133,7 +133,7 @@ func TestCreateStackAndGetResources_NoSubnet(t *testing.T) {
 		StackEvents: mockedEvents,
 	}
 
-	_, _, _, _, err := testCfn.CreateStackAndGetResources(testAzs, nil, "")
+	_, _, _, _, err := testCfn.CreateStackAndGetResources(testAzs, aws.String(cfn.DefaultStackName), "")
 	th.Nok(t, err)
 }
 
@@ -152,7 +152,7 @@ func TestCreateStackAndGetResources_NoVpc(t *testing.T) {
 		StackEvents: mockedEvents,
 	}
 
-	_, _, _, _, err := testCfn.CreateStackAndGetResources(testAzs, nil, "")
+	_, _, _, _, err := testCfn.CreateStackAndGetResources(testAzs, aws.String(cfn.DefaultStackName), "")
 	th.Nok(t, err)
 }
 

--- a/pkg/ec2helper/ec2helper.go
+++ b/pkg/ec2helper/ec2helper.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 
 	"simple-ec2/pkg/cfn"
@@ -1117,6 +1118,14 @@ func (h *EC2Helper) LaunchSpotInstance(simpleConfig *config.SimpleInfo, detailed
 		if simpleConfig.LaunchTemplateId != "" {
 			_, err = h.LaunchFleet(aws.String(simpleConfig.LaunchTemplateId))
 		} else {
+			// Create new stack, if specified.
+			if simpleConfig.NewVPC {
+				err := h.createNetworkConfiguration(simpleConfig, nil)
+				if err != nil {
+					return err
+				}
+			}
+
 			template, err := h.CreateLaunchTemplate(simpleConfig, detailedConfig)
 			if err != nil {
 				if aerr, ok := err.(awserr.Error); ok {
@@ -1171,7 +1180,9 @@ func (h *EC2Helper) createNetworkConfiguration(simpleConfig *config.SimpleInfo,
 		return errors.New("No subnet with the selected availability zone found")
 	}
 
-	input.SubnetId = selectedSubnetId
+	if input != nil {
+		input.SubnetId = selectedSubnetId
+	}
 
 	/*
 		Get the security group.
@@ -1208,7 +1219,9 @@ func (h *EC2Helper) createNetworkConfiguration(simpleConfig *config.SimpleInfo,
 		return errors.New("No security group available for stack")
 	}
 
-	input.SecurityGroupIds = aws.StringSlice(selectedSecurityGroupIds)
+	if input != nil {
+		input.SecurityGroupIds = aws.StringSlice(selectedSecurityGroupIds)
+	}
 
 	// Update simpleConfig for config saving
 	simpleConfig.NewVPC = false
@@ -1280,6 +1293,15 @@ func ValidateTags(h *EC2Helper, userTags string) bool {
 		if len(strings.Split(rawTag, "|")) != 2 { //[tag1,val1]
 			return false
 		}
+	}
+	return true
+}
+
+// ValidateInteger checks if a given string is an integer
+func ValidateInteger(h *EC2Helper, intString string) bool {
+	_, err := strconv.Atoi(intString)
+	if err != nil {
+		return false
 	}
 	return true
 }

--- a/pkg/ec2helper/ec2helper_test.go
+++ b/pkg/ec2helper/ec2helper_test.go
@@ -1390,6 +1390,26 @@ func TestValidateTags_False(t *testing.T) {
 	th.Equals(t, false, result)
 }
 
+func TestValidateInteger_True(t *testing.T) {
+	testUserInput := "123"
+	result := ec2helper.ValidateInteger(testEC2, testUserInput)
+	th.Equals(t, true, result)
+}
+
+func TestValidateInteger_False(t *testing.T) {
+	floatInput := "123.456"
+	floatResult := ec2helper.ValidateInteger(testEC2, floatInput)
+	th.Equals(t, false, floatResult)
+
+	stringInput := "abcdefg"
+	stringResult := ec2helper.ValidateInteger(testEC2, stringInput)
+	th.Equals(t, false, stringResult)
+
+	alphanumericInput := "123abc"
+	alphanumericResult := ec2helper.ValidateInteger(testEC2, alphanumericInput)
+	th.Equals(t, false, alphanumericResult)
+}
+
 func TestIsLinux_True(t *testing.T) {
 	actualIsLinux := ec2helper.IsLinux(ec2.CapacityReservationInstancePlatformLinuxUnix)
 	th.Equals(t, true, actualIsLinux)


### PR DESCRIPTION
**Issue #, if available:** #96

**Description of changes:**
These changes lay the groundwork for the new questionnaire built on Bubble Tea, but they're independent enough of the other changes that we can merge them now.

* Ensure new VPC gets created when requested
* Append unique string to VPC name when creating, to prevent collisions
* Add nil checks on security group and subnet parameters
* New ValidateInteger function, for input validation on plainText questions type

@GavinBurris42 wrote this code during his internship. What you see in this PR is the final result of multiple reviews (https://github.com/GavinBurris42/aws-simple-ec2-cli/pull/9 and https://github.com/GavinBurris42/aws-simple-ec2-cli/pull/10) that I conducted, plus some new unit tests I wrote.

**Testing:**

Build passes locally, including unit tests and end-to-end tests. But the real test is that we ran full manual end-to-end tests with all the Bubble Tea changes together (coming in later PRs).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
