### PR TITLE
Fix AMI filtering to include owner-alias

### DIFF
--- a/pkg/ec2helper/ec2helper.go
+++ b/pkg/ec2helper/ec2helper.go
@@ -408,6 +408,12 @@ func getDescribeImagesInputs(rootDeviceType string, architectures []*string) *ma
 						Name:   aws.String("architecture"),
 						Values: architectures,
 					},
+					{
+						Name: aws.String("owner-alias"),
+						Values: []*string{
+							aws.String("amazon"),
+						},
+					},
 				},
 			}
 		}


### PR DESCRIPTION
**Issue #, if available:** https://t.corp.amazon.com/P167735173/overview

**Description of changes:**
- Included owner filtering along with other filters to list images

**Testing:**
- Tested locally and tried to reproduce the issue mentioned in the ticket.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
